### PR TITLE
feat: add highlight for executable files

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -749,6 +749,9 @@ OilFile                                                               *hl-OilFil
 OilFileHidden                                                   *hl-OilFileHidden*
     Hidden normal files in an oil buffer
 
+OilExecutable                                                   *hl-OilExecutable*
+    Executable files in an oil buffer
+
 OilCreate                                                           *hl-OilCreate*
     Create action in the oil preview window
 

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -924,6 +924,11 @@ M._get_highlights = function()
       desc = "Hidden normal files in an oil buffer",
     },
     {
+      name = "OilExecutable",
+      link = "DiagnosticOk",
+      desc = "Executable files in an oil buffer",
+    },
+    {
       name = "OilCreate",
       link = "DiagnosticInfo",
       desc = "Create action in the oil preview window",


### PR DESCRIPTION
## Problem

Executable files were visually indistinguishable from regular files in oil buffers.

## Solution

Add `OilExecutable` highlight group (linked to `DiagnosticOk`) that detects executables via Unix permission bits (`S_IXUSR|S_IXGRP|S_IXOTH`) and Windows executable extensions (`.exe`, `.bat`, `.cmd`, `.com`, `.ps1`). Applied to both regular files and symlink targets.

Ref: stevearc/oil.nvim#698, stevearc/oil.nvim#679