### PR TITLE
feat: add configurable file and directory creation permissions

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -122,6 +122,10 @@ CONFIG                                                                *oil-confi
           return nil
         end,
       },
+      -- Permission mode for new files (default 420 = 0644)
+      new_file_mode = 420,
+      -- Permission mode for new directories (default 493 = 0755)
+      new_dir_mode = 493,
       -- Extra arguments to pass to SCP when moving/copying files over SSH
       extra_scp_args = {},
       -- Extra arguments to pass to aws s3 when creating/deleting/moving/copying files using aws s3

--- a/lua/oil/adapters/files.lua
+++ b/lua/oil/adapters/files.lua
@@ -580,14 +580,14 @@ M.perform_action = function(action, cb)
     end
 
     if action.entry_type == "directory" then
-      uv.fs_mkdir(path, 493, function(err)
+      uv.fs_mkdir(path, config.new_dir_mode, function(err)
         -- Ignore if the directory already exists
         if not err or err:match("^EEXIST:") then
           cb()
         else
           cb(err)
         end
-      end) -- 0755
+      end)
     elseif action.entry_type == "link" and action.link then
       local flags = nil
       local target = fs.posix_to_os_path(action.link)
@@ -600,7 +600,7 @@ M.perform_action = function(action, cb)
       ---@diagnostic disable-next-line: param-type-mismatch
       uv.fs_symlink(target, path, flags, cb)
     else
-      fs.touch(path, cb)
+      fs.touch(path, config.new_file_mode, cb)
     end
   elseif action.type == "delete" then
     local _, path = util.parse_url(action.url)

--- a/lua/oil/adapters/trash/mac.lua
+++ b/lua/oil/adapters/trash/mac.lua
@@ -166,7 +166,7 @@ M.perform_action = function(action, cb)
       ---@diagnostic disable-next-line: param-type-mismatch
       uv.fs_symlink(target, path, flags, cb)
     else
-      fs.touch(path, cb)
+      fs.touch(path, config.new_file_mode, cb)
     end
   elseif action.type == "delete" then
     local _, path = util.parse_url(action.url)

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -105,6 +105,8 @@ local default_config = {
       return nil
     end,
   },
+  new_file_mode = 420,
+  new_dir_mode = 493,
   -- Extra arguments to pass to SCP when moving/copying files over SSH
   extra_scp_args = {},
   -- Extra arguments to pass to aws s3 when creating/deleting/moving/copying files using aws s3
@@ -239,6 +241,8 @@ default_config.view_options.highlight_filename = nil
 ---@field keymaps table<string, any>
 ---@field use_default_keymaps boolean
 ---@field view_options oil.ViewOptions
+---@field new_file_mode integer
+---@field new_dir_mode integer
 ---@field extra_scp_args string[]
 ---@field extra_s3_args string[]
 ---@field git oil.GitOptions
@@ -268,6 +272,8 @@ local M = {}
 ---@field keymaps? table<string, any>
 ---@field use_default_keymaps? boolean Set to false to disable all of the above keymaps
 ---@field view_options? oil.SetupViewOptions Configure which files are shown and how they are shown.
+---@field new_file_mode? integer Permission mode for new files in decimal (default 420 = 0644)
+---@field new_dir_mode? integer Permission mode for new directories in decimal (default 493 = 0755)
 ---@field extra_scp_args? string[] Extra arguments to pass to SCP when moving/copying files over SSH
 ---@field extra_s3_args? string[] Extra arguments to pass to aws s3 when moving/copying files using aws s3
 ---@field git? oil.SetupGitOptions EXPERIMENTAL support for performing file operations with git

--- a/lua/oil/fs.lua
+++ b/lua/oil/fs.lua
@@ -37,9 +37,14 @@ M.abspath = function(path)
 end
 
 ---@param path string
+---@param mode? integer File mode in decimal (default 420 = 0644)
 ---@param cb fun(err: nil|string)
-M.touch = function(path, cb)
-  uv.fs_open(path, "a", 420, function(err, fd) -- 0644
+M.touch = function(path, mode, cb)
+  if type(mode) == "function" then
+    cb = mode
+    mode = 420
+  end
+  uv.fs_open(path, "a", mode or 420, function(err, fd)
     if err then
       cb(err)
     else


### PR DESCRIPTION
## Problem

Files were always created with mode 0644 and directories with 0755, hardcoded in fs.touch and uv.fs_mkdir. Users who need different defaults had no config option.

## Solution

Add `new_file_mode` (default 420 = 0644) and `new_dir_mode` (default 493 = 0755) config options, passed through to `fs.touch` and `uv.fs_mkdir` in the files and mac trash adapters.

Fixes from the original PR (stevearc/oil.nvim#537):
- Fixed critical `mkdirp` bug where the `mod` string variable (used for `fnamemodify` path traversal) was being reassigned to the integer `mode` value, completely breaking directory creation
- Fixed SSH adapter misapplying user-configured dir mode to local cache directories
- Made `fs.touch` signature backwards-compatible via type-checking the mode parameter

Ref: stevearc/oil.nvim#537