### PR TITLE
fix: hijack all directory buffers at setup, not just current

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1446,9 +1446,10 @@ M.setup = function(opts)
       end,
     })
 
-    local bufnr = vim.api.nvim_get_current_buf()
-    if maybe_hijack_directory_buffer(bufnr) and vim.v.vim_did_enter == 1 then
-      M.load_oil_buffer(bufnr)
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      if maybe_hijack_directory_buffer(bufnr) and vim.v.vim_did_enter == 1 then
+        M.load_oil_buffer(bufnr)
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

When neovim is opened with multiple directory arguments (e.g.
`nvim dir1/ dir2/`), only the first directory gets handled by oil. The
`BufAdd` autocmd is registered inside `setup()`, but neovim creates all
argument buffers before `setup()` runs. The initial hijack block only
processes `nvim_get_current_buf()`, leaving additional directory buffers
as plain empty buffers that never become oil listings.

Reported upstream: stevearc/oil.nvim#670

## Solution

Iterate all existing buffers at setup time instead of only the current
one. Each directory buffer gets renamed to an `oil://` URL so that
`BufReadCmd` fires when the user switches to it.

Verified manually: `nvim --clean -u repro.lua /tmp/dir1/ /tmp/dir2/`
followed by `:buffer 2` now shows a proper oil listing.
Full test suite passes (111 tests).