### PR TITLE
fix(preview): prevent preview from re-initializing modified oil buffers

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -602,7 +602,7 @@ M.open_preview = function(opts, callback)
 
     -- If we called open_preview during an autocmd, then the edit command may not trigger the
     -- BufReadCmd to load the buffer. So we need to do it manually.
-    if util.is_oil_bufnr(filebufnr) then
+    if util.is_oil_bufnr(filebufnr) and not vim.b[filebufnr].oil_ready then
       M.load_oil_buffer(filebufnr)
     end
 


### PR DESCRIPTION
## Problem

When the preview window opens a directory that already has a loaded oil
buffer with unsaved edits, `open_preview()` unconditionally calls
`load_oil_buffer()` on it. This re-initializes the buffer via
`view.initialize()` → `render_buffer_async()`, which re-fetches the
directory listing from disk and replaces all buffer lines, destroying
the user's pending edits (e.g. a cut line). The mutation parser then
can't see the deleted entry in the source buffer, producing a COPY
action instead of a MOVE.

Reproduction: open oil with preview, `dd` a file, navigate to parent
with `-`, paste, `:w` — confirmation shows COPY instead of MOVE.

Reported upstream: stevearc/oil.nvim#632

## Solution

Guard the `load_oil_buffer()` call in `open_preview()` with a check
for `vim.b[filebufnr].oil_ready`. Buffers that are already initialized
and rendered skip re-loading, preserving any unsaved modifications.

Verified manually: same repro now correctly produces MOVE.
Full test suite passes (111 tests).