### PR TITLE
build: add luarocks packaging and bump stylua

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,21 @@
+name: luarocks
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+
+  publish:
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: nvim-neorocks/luarocks-tag-release@v7
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.0.2
+          version: v2.1.0
           args: --check lua tests
 
   typecheck:

--- a/oil.nvim-scm-1.rockspec
+++ b/oil.nvim-scm-1.rockspec
@@ -1,0 +1,21 @@
+rockspec_format = '3.0'
+package = 'oil.nvim'
+version = 'scm-1'
+
+source = {
+  url = 'git+https://github.com/barrettruth/oil.nvim.git',
+}
+
+description = {
+  summary = 'Neovim file explorer: edit your filesystem like a buffer',
+  homepage = 'https://github.com/barrettruth/oil.nvim',
+  license = 'MIT',
+}
+
+dependencies = {
+  'lua >= 5.1',
+}
+
+build = {
+  type = 'builtin',
+}


### PR DESCRIPTION
## Problem

oil.nvim had no luarocks rockspec, so users of rocks.nvim and similar tools
could not install it from the registry. The stylua CI action was also pinned to
an older version.

## Solution

Add scm-1 rockspec and a luarocks publish workflow that gates on tests passing
before publishing on version tags. Bump stylua action from v2.0.2 to v2.1.0.

Note: the `LUAROCKS_API_KEY` secret needs to be added to the repo settings
before the first tagged release.

Closes #14