### PR TITLE
fix(ci): switch typecheck action to stevearc/nvim-typecheck-action

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -62,12 +62,10 @@ jobs:
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Run Lua LS Type Check
-        uses: mrcjkb/lua-typecheck-action@v0
+      - uses: stevearc/nvim-typecheck-action@v2
         with:
-          checklevel: Warning
-          directories: lua
-          configpath: .luarc.json
+          path: lua
+          luals-version: 3.16.4
 
   markdown-format:
     name: Markdown Format Check

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,8 +1,15 @@
 {
-  "runtime.version": "Lua 5.1",
-  "runtime.path": ["lua/?.lua", "lua/?/init.lua"],
-  "diagnostics.globals": ["vim", "jit", "bit"],
-  "workspace.library": ["$VIMRUNTIME/lua", "${3rd}/luv/library"],
-  "workspace.checkThirdParty": false,
-  "completion.callSnippet": "Replace"
+  "runtime": {
+    "version": "LuaJIT",
+    "pathStrict": true
+  },
+  "workspace": {
+    "checkThirdParty": false
+  },
+  "type": {
+    "checkTableShape": true
+  },
+  "completion": {
+    "callSnippet": "Replace"
+  }
 }

--- a/selene.toml
+++ b/selene.toml
@@ -1,4 +1,5 @@
 std = 'vim'
+exclude = [".direnv/*"]
 
 [lints]
 mixed_table = 'allow'


### PR DESCRIPTION
## Problem

The typecheck CI job fails on every run because `mrcjkb/lua-typecheck-action@v0`
runs lua-language-server in a bare nix sandbox without neovim installed. The
`.luarc.json` references `$VIMRUNTIME` and `${3rd}/luv/library` which cannot
resolve in that environment, producing 71 type errors for all `vim.*` and `uv.*`
types.

## Solution

Switch to `stevearc/nvim-typecheck-action@v2`, which installs neovim and
auto-clones luvit-meta for luv type stubs. This matches upstream oil.nvim's CI
configuration and resolves all type errors. Also add `.direnv/*` to
`selene.toml` exclude to suppress false positives from nix store lua files when
running selene locally.