### PR TITLE
feat(icons): add nonicons.nvim icon provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://user-images.githubusercontent.com/506791/209727111-6b4a11f4-634a-4efa-94
 ## Requirements
 
 - Neovim 0.10+
-- File icons (any one of):
+- (Optionally) any of the following icon providers:
   - [mini.icons](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-icons.md)
   - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
   - [nonicons.nvim](https://github.com/barrettruth/nonicons.nvim)

--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -945,27 +945,6 @@ M.get_icon_provider = function()
     end
   end
 
-  -- fallback to `nvim-web-devicons`
-  local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
-  if has_devicons then
-    return function(type, name, conf, ft)
-      if type == 'directory' then
-        return conf and conf.directory or '', 'OilDirIcon'
-      else
-        if ft then
-          local ft_icon, ft_hl = devicons.get_icon_by_filetype(ft)
-          if ft_icon and ft_icon ~= '' then
-            return ft_icon, ft_hl
-          end
-        end
-        local icon, hl = devicons.get_icon(name)
-        hl = hl or 'OilFileIcon'
-        icon = icon or (conf and conf.default_file or '')
-        return icon, hl
-      end
-    end
-  end
-
   local has_nonicons, nonicons = pcall(require, 'nonicons')
   if has_nonicons and type(nonicons.get) == 'function' then
     return function(type, name, conf, ft)
@@ -988,6 +967,26 @@ M.get_icon_provider = function()
         end
         local icon = nonicons.get('file')
         return icon or (conf and conf.default_file or ''), 'OilFileIcon'
+      end
+    end
+  end
+
+  local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
+  if has_devicons then
+    return function(type, name, conf, ft)
+      if type == 'directory' then
+        return conf and conf.directory or '', 'OilDirIcon'
+      else
+        if ft then
+          local ft_icon, ft_hl = devicons.get_icon_by_filetype(ft)
+          if ft_icon and ft_icon ~= '' then
+            return ft_icon, ft_hl
+          end
+        end
+        local icon, hl = devicons.get_icon(name)
+        hl = hl or 'OilFileIcon'
+        icon = icon or (conf and conf.default_file or '')
+        return icon, hl
       end
     end
   end


### PR DESCRIPTION
## Problem

oil.nvim only recognizes mini.icons and nvim-web-devicons as icon providers.
nonicons.nvim works when paired with devicons (via its `apply()` monkey-patch),
but has no standalone support — users with only nonicons installed get no icons.

## Solution

Add a nonicons.nvim fallback in `get_icon_provider()`, placed after devicons so
the patched devicons path is preferred when both are installed. The standalone
path handles directories via `nonicons.get('file-directory')`, files via
filetype/extension lookup, with a generic file icon fallback.

Priority chain is now: mini.icons → nvim-web-devicons → nonicons → nil.