### PR TITLE
feat(icons): add direct nonicons.nvim icon provider

### DIFF
--- a/lua/oil/util.lua
+++ b/lua/oil/util.lua
@@ -945,6 +945,28 @@ M.get_icon_provider = function()
     end
   end
 
+  local has_nonicons, nonicons = pcall(require, 'nonicons')
+  if has_nonicons and nonicons.get_icon then
+    return function(type, name, conf, ft)
+      if type == 'directory' then
+        local icon = nonicons.get('file-directory')
+        return icon or (conf and conf.directory or ''), 'OilDirIcon'
+      end
+      if ft then
+        local ft_icon = nonicons.get_icon_by_filetype(ft)
+        if ft_icon then
+          return ft_icon, 'OilFileIcon'
+        end
+      end
+      local icon = nonicons.get_icon(name)
+      if icon then
+        return icon, 'OilFileIcon'
+      end
+      local fallback = nonicons.get('file')
+      return fallback or (conf and conf.default_file or ''), 'OilFileIcon'
+    end
+  end
+
   local has_devicons, devicons = pcall(require, 'nvim-web-devicons')
   if has_devicons then
     return function(type, name, conf, ft)


### PR DESCRIPTION
## Problem

oil.nvim can only use nonicons glyphs indirectly through the devicons
monkey-patch. This couples oil to devicons even when nonicons is
available standalone with its new `get_icon`/`get_icon_by_filetype` API.

## Solution

Add a nonicons provider in `get_icon_provider()` between mini.icons and
devicons. Feature-gated on `nonicons.get_icon` existing so old nonicons
versions fall through to devicons. Uses `OilDirIcon` and `OilFileIcon`
highlight groups.