### PR TITLE
ci(digest): use fixed branch with force-push for weekly digest

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -15,6 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Close existing digest PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list \
+            --repo barrettruth/canola.nvim \
+            --label "upstream/digest" \
+            --state open \
+            --json number \
+            --jq '.[].number' \
+          | xargs -r -I{} gh pr close {} \
+              --repo barrettruth/canola.nvim \
+              --delete-branch
+
       - name: Update upstream tracker
         id: digest
         env:
@@ -42,5 +56,6 @@ jobs:
             --title "docs(upstream): add digest for week of ${DATE}" \
             --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
             --base main \
-            --head "${BRANCH}")
+            --head "${BRANCH}" \
+            --label "upstream/digest")
           gh pr merge "${PR_URL}" --auto --squash


### PR DESCRIPTION
## Problem

The digest workflow created a new dated branch each run, leading to accumulating PRs if they weren't merged before the next run.

## Solution

Use a single canonical branch `ci/upstream-digest` with `--force` push. Each weekly run resets the branch to main, re-fetches everything since the last merged baseline, and force-pushes. If a PR is already open for the branch, GitHub updates it automatically. A new PR is only created (with auto-merge enabled) when none exists.