### PR TITLE
ci(digest): remove PAT approval step

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -43,6 +43,5 @@ jobs:
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \
               --head "${BRANCH}")
-            GH_TOKEN="${{ secrets.DIGEST_PAT }}" gh pr review "${PR_URL}" --approve
             gh pr merge "${PR_URL}" --auto --squash
           fi


### PR DESCRIPTION
Auto-approve already handles the review requirement. The explicit PAT approval step is redundant.