### PR TITLE
ci(digest): create digest PR with PAT so CI triggers

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -38,7 +38,7 @@ jobs:
           git commit -m "docs(upstream): upstream digest $(date +%Y-%m-%d)"
           git push --force origin "${BRANCH}"
           if ! gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
-            PR_URL=$(gh pr create \
+            PR_URL=$(GH_TOKEN="${{ secrets.DIGEST_PAT }}" gh pr create \
               --title "docs(upstream): upstream digest" \
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN`-created PRs suppress `pull_request` workflow triggers (GitHub's loop-prevention mechanism), so CI never runs and auto-merge stalls indefinitely.

## Solution

Use `DIGEST_PAT` to create the digest PR. A PAT-created PR is treated as a real user action, triggering CI normally. Auto-approve handles the review requirement, auto-merge fires when checks pass.