### PR TITLE
docs(upstream): upstream digest

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -46,6 +46,7 @@ Bugs fixed in this fork that remain open upstream.
 | [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming          | deferred — needs rewrite                                                             |
 | [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents     | open                                                                                 |
 | [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split     | tracked — [#2](https://github.com/barrettruth/canola.nvim/issues/2)                  |
+| [#735](https://github.com/stevearc/oil.nvim/pull/735) | gX opens external program with a selection. | open                                                                                 |
 
 ## Upstream issues
 
@@ -161,3 +162,4 @@ addressed, `open` = not yet triaged.
 | [#714](https://github.com/stevearc/oil.nvim/issues/714) | not actionable | Support question — answered                                                                                                                                    |
 | [#719](https://github.com/stevearc/oil.nvim/issues/719) | not actionable | Neovim crash on node_modules — libuv/neovim bug                                                                                                                |
 | [#726](https://github.com/stevearc/oil.nvim/issues/726) | not actionable | Meta discussion/roadmap                                                                                                                                        |
+| [#736](https://github.com/stevearc/oil.nvim/issues/736) | open           | feature request: make icons virtual text                                                                                                                       |


### PR DESCRIPTION
Automated weekly digest of new upstream activity. Triage by updating statuses and notes.