### PR TITLE
ci(digest): run CI on push to ci/upstream-digest branch

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, ci/upstream-digest]
 
 jobs:
   changes:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, ci/upstream-digest]
 
 jobs:
   test:

--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -38,7 +38,7 @@ jobs:
           git commit -m "docs(upstream): upstream digest $(date +%Y-%m-%d)"
           git push --force origin "${BRANCH}"
           if ! gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
-            PR_URL=$(GH_TOKEN="${{ secrets.DIGEST_PAT }}" gh pr create \
+            PR_URL=$(gh pr create \
               --title "docs(upstream): upstream digest" \
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \


### PR DESCRIPTION
## Problem

`GITHUB_TOKEN`-created PRs suppress `pull_request` triggers, so CI never runs and auto-merge stalls. Using a PAT to create the PR works but inflates contribution count.

## Solution

Add `ci/upstream-digest` to the `push` trigger in `test` and `quality`. CI runs on the branch push before the PR is opened; check results attach to the commit SHA so the PR sees them as already passing. The digest workflow reverts to `GITHUB_TOKEN` for PR creation — no PAT needed, no contribution inflation. You approve manually, auto-merge fires.