### PR TITLE
ci(digest): unset checkout extraheader so PAT push triggers CI

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -36,6 +36,7 @@ jobs:
           git checkout -b "${BRANCH}"
           git add doc/upstream.md
           git commit -m "docs(upstream): upstream digest $(date +%Y-%m-%d)"
+          git config --unset http.https://github.com/.extraheader
           git remote set-url origin "https://x-access-token:${{ secrets.DIGEST_PAT }}@github.com/barrettruth/canola.nvim.git"
           git push --force origin "${BRANCH}"
           if ! GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then


### PR DESCRIPTION
## Problem

`actions/checkout` sets `http.https://github.com/.extraheader` with `GITHUB_TOKEN`, which overrides any credentials in the remote URL. The PAT in the remote URL is silently ignored, so the push goes through as the bot — suppressing CI triggers.

## Solution

Unset the extraheader before pushing so git uses the `DIGEST_PAT` embedded in the remote URL. The push is attributed to barrettruth, CI fires, auto-approve and auto-merge follow.