### PR TITLE
ci(digest): approve with GITHUB_TOKEN not PAT

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -45,6 +45,6 @@ jobs:
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \
               --head "${BRANCH}")
-            GH_TOKEN="${{ secrets.DIGEST_PAT }}" gh pr review "${PR_URL}" --approve
+            gh pr review "${PR_URL}" --approve
             GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh pr merge "${PR_URL}" --auto --squash
           fi


### PR DESCRIPTION
## Problem

`require_last_push_approval` blocks the last pusher (barrettruth via PAT) from approving their own PR.

## Solution

Use `GITHUB_TOKEN` (the bot) to approve — a different actor from the PAT pusher, satisfying the rule. barrettruth pushes via PAT (triggers CI), the bot approves, auto-merge fires when CI passes.