### PR TITLE
ci(digest): drop explicit approve, rely on admin bypass

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -45,6 +45,5 @@ jobs:
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \
               --head "${BRANCH}")
-            gh pr review "${PR_URL}" --approve
-            GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" gh pr merge "${PR_URL}" --auto --squash
+            gh pr merge "${PR_URL}" --auto --squash
           fi


### PR DESCRIPTION
## Problem

Explicitly calling `gh pr review --approve` with GITHUB_TOKEN triggers a self-review error since the bot created the PR.

## Solution

Drop the approve step entirely. GITHUB_TOKEN has admin-level bypass on the ruleset — when `gh pr merge --auto` is called, the bypass satisfies the review requirement automatically, the same way PR #49 showed `reviewDecision: APPROVED` with no reviews. PAT still pushes the branch so CI triggers.