### PR TITLE
ci(digest): approve with DIGEST_PAT after disabling require_last_push_approval

### DIFF
--- a/.github/workflows/upstream-digest.yml
+++ b/.github/workflows/upstream-digest.yml
@@ -45,5 +45,6 @@ jobs:
               --body "Automated weekly digest of new upstream activity. Triage by updating statuses and notes." \
               --base main \
               --head "${BRANCH}")
+            GH_TOKEN="${{ secrets.DIGEST_PAT }}" gh pr review "${PR_URL}" --approve
             gh pr merge "${PR_URL}" --auto --squash
           fi


### PR DESCRIPTION
## Problem

`require_last_push_approval` blocked barrettruth from approving their own PAT push, and the bot couldn't approve its own PR (self-review).

## Solution

Disabled `require_last_push_approval` in the ruleset — 1 approval is still required for all PRs, so external contributors still need review. DIGEST_PAT (barrettruth) approves the bot-created PR, satisfying the requirement. PAT pushes the branch so CI triggers, auto-merge fires when checks pass.