### PR TITLE
fix: escape on save prompt cancels select

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -37,17 +37,17 @@ Bugs fixed in this fork that remain open upstream.
 
 ## Open upstream PRs
 
-| PR                                                    | Description                                 | Status                                                                                          |
-| ----------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [#488](https://github.com/stevearc/oil.nvim/pull/488) | Parent directory in a split                 | not actionable — empty PR                                                                       |
-| [#493](https://github.com/stevearc/oil.nvim/pull/493) | UNC paths on Windows                        | not actionable — superseded by [#686](https://github.com/stevearc/oil.nvim/pull/686)            |
-| [#591](https://github.com/stevearc/oil.nvim/pull/591) | release-please changelog                    | not applicable                                                                                  |
-| [#667](https://github.com/stevearc/oil.nvim/pull/667) | Virtual text columns + headers              | deferred — WIP, conflicting                                                                     |
-| [#686](https://github.com/stevearc/oil.nvim/pull/686) | Windows path conversion fix                 | not actionable — Windows-only                                                                   |
-| [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming          | deferred — needs rewrite                                                                        |
-| [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents     | fixed — `CanolaFileCreated` autocmd — [#75](https://github.com/barrettruth/canola.nvim/pull/75) |
-| [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split     | tracked — [#2](https://github.com/barrettruth/canola.nvim/issues/2)                             |
-| [#735](https://github.com/stevearc/oil.nvim/pull/735) | gX opens external program with a selection. | not actionable — wrong abstraction layer                                                        |
+| PR                                                    | Description                              | Status                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [#488](https://github.com/stevearc/oil.nvim/pull/488) | Parent directory in a split              | not actionable — empty PR                                                                             |
+| [#493](https://github.com/stevearc/oil.nvim/pull/493) | UNC paths on Windows                     | not actionable — superseded by [#686](https://github.com/stevearc/oil.nvim/pull/686)                  |
+| [#591](https://github.com/stevearc/oil.nvim/pull/591) | release-please changelog                 | not applicable                                                                                        |
+| [#667](https://github.com/stevearc/oil.nvim/pull/667) | Virtual text columns + headers           | deferred — WIP, conflicting                                                                           |
+| [#686](https://github.com/stevearc/oil.nvim/pull/686) | Windows path conversion fix              | not actionable — Windows-only                                                                         |
+| [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming       | deferred — needs rewrite                                                                              |
+| [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents  | deferred — fixing via autocmd event on file create                                                    |
+| [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split  | tracked — [#2](https://github.com/barrettruth/canola.nvim/issues/2)                                   |
+| [#735](https://github.com/stevearc/oil.nvim/pull/735) | gX opens external program with selection | not actionable — hardcoded Linux-only program list, no config surface, author-acknowledged incomplete |
 
 ## Upstream issues
 
@@ -82,7 +82,7 @@ Bugs fixed in this fork that remain open upstream.
 | [#359](https://github.com/stevearc/oil.nvim/issues/359) | open           | Parse error on filenames differing by space (P1)                                                                                                                         |
 | [#360](https://github.com/stevearc/oil.nvim/issues/360) | open           | Pick window to open file into                                                                                                                                            |
 | [#362](https://github.com/stevearc/oil.nvim/issues/362) | open           | "Could not find oil adapter for scheme" error                                                                                                                            |
-| [#363](https://github.com/stevearc/oil.nvim/issues/363) | open           | `prompt_save_on_select_new_entry` uses wrong prompt                                                                                                                      |
+| [#363](https://github.com/stevearc/oil.nvim/issues/363) | fixed          | `prompt_save_on_select_new_entry` uses wrong prompt — escape now cancels select                                                                                          |
 | [#371](https://github.com/stevearc/oil.nvim/issues/371) | open           | Constrain cursor in insert mode                                                                                                                                          |
 | [#373](https://github.com/stevearc/oil.nvim/issues/373) | open           | Dir from quickfix with bqf/trouble broken (P1)                                                                                                                           |
 | [#375](https://github.com/stevearc/oil.nvim/issues/375) | open           | Highlights for file types and permissions (P2)                                                                                                                           |

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -716,6 +716,8 @@ M.select = function(opts, callback)
     local ok, choice = pcall(vim.fn.confirm, 'Save changes?', 'Yes\nNo', 1)
     if not ok then
       return finish()
+    elseif choice == 0 then
+      return
     elseif choice == 1 then
       M.save()
       return finish()


### PR DESCRIPTION
## Problem

When `prompt_save_on_select_new_entry` is enabled, pressing Escape on the "Save changes?" confirm dialog causes `vim.fn.confirm` to return 0. The code had no branch for this case, so the select continued as if the user chose "No", opening the file despite the user's intent to cancel.

## Solution

Add an explicit `choice == 0` guard in `M.select` that returns immediately when the user presses Escape, aborting the select without saving or opening any files.