### PR TITLE
feat: add `skip_confirm_for_delete` option

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -292,6 +292,11 @@ skip_confirm_for_simple_edits                  *canola.skip_confirm_for_simple_e
         * contain at most one copy or move
         * contain at most five creates
 
+skip_confirm_for_delete                              *canola.skip_confirm_for_delete*
+    type: `boolean` default: `false`
+    When this option is `true`, the confirmation popup will be skipped if all pending
+    actions are deletes.
+
 prompt_save_on_select_new_entry              *canola.prompt_save_on_select_new_entry*
     type: `boolean` default: `true`
     There are two cases where this option is relevant:

--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -37,17 +37,17 @@ Bugs fixed in this fork that remain open upstream.
 
 ## Open upstream PRs
 
-| PR                                                    | Description                                 | Status                                                                                          |
-| ----------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [#488](https://github.com/stevearc/oil.nvim/pull/488) | Parent directory in a split                 | not actionable — empty PR                                                                       |
-| [#493](https://github.com/stevearc/oil.nvim/pull/493) | UNC paths on Windows                        | not actionable — superseded by [#686](https://github.com/stevearc/oil.nvim/pull/686)            |
-| [#591](https://github.com/stevearc/oil.nvim/pull/591) | release-please changelog                    | not applicable                                                                                  |
-| [#667](https://github.com/stevearc/oil.nvim/pull/667) | Virtual text columns + headers              | deferred — WIP, conflicting                                                                     |
-| [#686](https://github.com/stevearc/oil.nvim/pull/686) | Windows path conversion fix                 | not actionable — Windows-only                                                                   |
-| [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming          | deferred — needs rewrite                                                                        |
-| [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents     | fixed — `CanolaFileCreated` autocmd — [#75](https://github.com/barrettruth/canola.nvim/pull/75) |
-| [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split     | tracked — [#2](https://github.com/barrettruth/canola.nvim/issues/2)                             |
-| [#735](https://github.com/stevearc/oil.nvim/pull/735) | gX opens external program with a selection. | not actionable — wrong abstraction layer                                                        |
+| PR                                                    | Description                              | Status                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [#488](https://github.com/stevearc/oil.nvim/pull/488) | Parent directory in a split              | not actionable — empty PR                                                                             |
+| [#493](https://github.com/stevearc/oil.nvim/pull/493) | UNC paths on Windows                     | not actionable — superseded by [#686](https://github.com/stevearc/oil.nvim/pull/686)                  |
+| [#591](https://github.com/stevearc/oil.nvim/pull/591) | release-please changelog                 | not applicable                                                                                        |
+| [#667](https://github.com/stevearc/oil.nvim/pull/667) | Virtual text columns + headers           | deferred — WIP, conflicting                                                                           |
+| [#686](https://github.com/stevearc/oil.nvim/pull/686) | Windows path conversion fix              | not actionable — Windows-only                                                                         |
+| [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming       | deferred — needs rewrite                                                                              |
+| [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents  | deferred — fixing via autocmd event on file create                                                    |
+| [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split  | tracked — [#2](https://github.com/barrettruth/canola.nvim/issues/2)                                   |
+| [#735](https://github.com/stevearc/oil.nvim/pull/735) | gX opens external program with selection | not actionable — hardcoded Linux-only program list, no config surface, author-acknowledged incomplete |
 
 ## Upstream issues
 
@@ -88,7 +88,7 @@ Bugs fixed in this fork that remain open upstream.
 | [#375](https://github.com/stevearc/oil.nvim/issues/375) | open           | Highlights for file types and permissions (P2)                                                                                                                           |
 | [#380](https://github.com/stevearc/oil.nvim/issues/380) | open           | Show file in oil when editing hidden file                                                                                                                                |
 | [#382](https://github.com/stevearc/oil.nvim/issues/382) | open           | Relative path in window title (P2)                                                                                                                                       |
-| [#392](https://github.com/stevearc/oil.nvim/issues/392) | open           | Option to skip delete prompt                                                                                                                                             |
+| [#392](https://github.com/stevearc/oil.nvim/issues/392) | fixed          | Option to skip delete prompt — fixed — `skip_confirm_for_delete` option                                                                                                  |
 | [#393](https://github.com/stevearc/oil.nvim/issues/393) | open           | Auto-save new buffer on entry                                                                                                                                            |
 | [#396](https://github.com/stevearc/oil.nvim/issues/396) | open           | Customize preview content (P2)                                                                                                                                           |
 | [#399](https://github.com/stevearc/oil.nvim/issues/399) | open           | Open file without closing Oil (P1)                                                                                                                                       |

--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -32,6 +32,7 @@ local default_config = {
   cleanup_buffers_on_delete = false,
   -- Skip the confirmation popup for simple operations (:help canola.skip_confirm_for_simple_edits)
   skip_confirm_for_simple_edits = false,
+  skip_confirm_for_delete = false,
   -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
   -- (:help prompt_save_on_select_new_entry)
   prompt_save_on_select_new_entry = true,
@@ -236,6 +237,7 @@ default_config.view_options.highlight_filename = nil
 ---@field delete_to_trash boolean
 ---@field cleanup_buffers_on_delete boolean
 ---@field skip_confirm_for_simple_edits boolean
+---@field skip_confirm_for_delete boolean
 ---@field prompt_save_on_select_new_entry boolean
 ---@field cleanup_delay_ms integer
 ---@field lsp_file_methods canola.LspFileMethods
@@ -268,6 +270,7 @@ local M = {}
 ---@field delete_to_trash? boolean Send deleted files to the trash instead of permanently deleting them (:help canola-trash).
 ---@field cleanup_buffers_on_delete? boolean Wipe open buffers for files deleted via canola (:help canola.cleanup_buffers_on_delete).
 ---@field skip_confirm_for_simple_edits? boolean Skip the confirmation popup for simple operations (:help canola.skip_confirm_for_simple_edits).
+---@field skip_confirm_for_delete? boolean Skip the confirmation popup when all pending actions are deletes (:help canola.skip_confirm_for_delete).
 ---@field prompt_save_on_select_new_entry? boolean Selecting a new/moved/renamed file or directory will prompt you to save changes first (:help prompt_save_on_select_new_entry).
 ---@field cleanup_delay_ms? integer Canola will automatically delete hidden buffers after this delay. You can set the delay to false to disable cleanup entirely. Note that the cleanup process only starts when none of the canola buffers are currently displayed.
 ---@field lsp_file_methods? canola.SetupLspFileMethods Configure LSP file operation integration.

--- a/lua/canola/mutator/confirmation.lua
+++ b/lua/canola/mutator/confirmation.lua
@@ -67,6 +67,19 @@ M.show = vim.schedule_wrap(function(actions, should_confirm, cb)
     cb(true)
     return
   end
+  if should_confirm == nil and config.skip_confirm_for_delete then
+    local all_deletes = true
+    for _, action in ipairs(actions) do
+      if action.type ~= 'delete' then
+        all_deletes = false
+        break
+      end
+    end
+    if all_deletes then
+      cb(true)
+      return
+    end
+  end
 
   -- Create the buffer
   local bufnr = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
## Problem

`skip_confirm_for_simple_edits` explicitly excludes deletes, so users who want to batch-delete files without a confirmation prompt had no opt-out. The upstream issue (stevearc/oil.nvim#392) has been open since 2023.

## Solution

Add `skip_confirm_for_delete = false` to config. When enabled, `confirmation.show()` skips the popup only when every pending action is a delete, leaving all other action combinations unaffected.