### PR TITLE
fix(ci): update digest script for reorganized upstream tracker

### DIFF
--- a/.github/scripts/upstream_digest.py
+++ b/.github/scripts/upstream_digest.py
@@ -10,8 +10,8 @@ from datetime import date, timedelta
 UPSTREAM = "stevearc/oil.nvim"
 UPSTREAM_MD = "doc/upstream.md"
 
-PRS_HEADING = "## Open upstream PRs"
-ISSUES_HEADING = "## Upstream issues"
+PRS_HEADING = "## Upstream PRs"
+ISSUES_HEADING = "## Issues — open"
 
 
 def get_last_tracked_number():
@@ -128,7 +128,7 @@ def main():
     issue_rows = []
     for issue in open_issues:
         issue_rows.append(
-            f"| [#{issue['number']}]({issue['url']}) | open | {issue['title']} |"
+            f"| [#{issue['number']}]({issue['url']}) | {issue['title']} |"
         )
 
     if pr_rows:


### PR DESCRIPTION
## Problem

The upstream digest script referenced old section headings (`## Open upstream PRs`, `## Upstream issues`) and a 3-column issue row format that no longer exist after the tracker reorganization in #89.

## Solution

Update headings to `## Upstream PRs` and `## Issues — open`, and change issue row format to the new 2-column layout.