### PR TITLE
docs(upstream): mark #207 fixed

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -39,7 +39,7 @@ issues against this fork.
 | [#117](https://github.com/stevearc/oil.nvim/issues/117) | Move file into new dir via slash in name | open |
 | [#156](https://github.com/stevearc/oil.nvim/issues/156) | Paste path of files into oil buffer | open |
 | [#200](https://github.com/stevearc/oil.nvim/issues/200) | Highlights not working when opening a file | open |
-| [#207](https://github.com/stevearc/oil.nvim/issues/207) | Suppress "no longer available" message | open |
+| [#207](https://github.com/stevearc/oil.nvim/issues/207) | Suppress "no longer available" message | fixed — `cleanup_buffers_on_delete` option |
 | [#210](https://github.com/stevearc/oil.nvim/issues/210) | FTP support | open |
 | [#213](https://github.com/stevearc/oil.nvim/issues/213) | Disable preview for large files | fixed ([#85](https://github.com/barrettruth/canola.nvim/pull/85)) |
 | [#226](https://github.com/stevearc/oil.nvim/issues/226) | K8s/Docker adapter | open |


### PR DESCRIPTION
## Problem

Issue #207 (suppress "no longer available" message) was listed as open but is already addressed by the existing `cleanup_buffers_on_delete` config option.

## Solution

Mark as fixed.