### PR TITLE
docs(upstream): mark #226 not actionable

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -42,7 +42,7 @@ issues against this fork.
 | [#207](https://github.com/stevearc/oil.nvim/issues/207) | Suppress "no longer available" message | fixed — `cleanup_buffers_on_delete` option |
 | [#210](https://github.com/stevearc/oil.nvim/issues/210) | FTP support | open |
 | [#213](https://github.com/stevearc/oil.nvim/issues/213) | Disable preview for large files | fixed ([#85](https://github.com/barrettruth/canola.nvim/pull/85)) |
-| [#226](https://github.com/stevearc/oil.nvim/issues/226) | K8s/Docker adapter | open |
+| [#226](https://github.com/stevearc/oil.nvim/issues/226) | K8s/Docker adapter | not actionable — no demand |
 | [#232](https://github.com/stevearc/oil.nvim/issues/232) | Cannot close last window | open |
 | [#254](https://github.com/stevearc/oil.nvim/issues/254) | Buffer modified highlight group | open |
 | [#263](https://github.com/stevearc/oil.nvim/issues/263) | Diff mode | open |


### PR DESCRIPTION
K8s/Docker adapter request — no demand, massive scope.