### PR TITLE
docs(upstream): revert #623 to open

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -105,7 +105,7 @@ issues against this fork.
 | [#615](https://github.com/stevearc/oil.nvim/issues/615) | Cursor at name column on o/O                               | fixed ([#72](https://github.com/barrettruth/canola.nvim/pull/72))                             |
 | [#617](https://github.com/stevearc/oil.nvim/issues/617) | Filetype by actual filetype                                | open                                                                                          |
 | [#621](https://github.com/stevearc/oil.nvim/issues/621) | `toggle()` for regular windows                             | fixed ([#88](https://github.com/barrettruth/canola.nvim/pull/88))                             |
-| [#623](https://github.com/stevearc/oil.nvim/issues/623) | bufferline.nvim interaction                                | not actionable — cross-plugin                                                                 |
+| [#623](https://github.com/stevearc/oil.nvim/issues/623) | bufferline.nvim interaction                                | open                                                                                          |
 | [#624](https://github.com/stevearc/oil.nvim/issues/624) | Mutation race                                              | not actionable — no reliable repro                                                            |
 | [#625](https://github.com/stevearc/oil.nvim/issues/625) | E19 mark invalid line                                      | not actionable — intractable without neovim API changes                                       |
 | [#632](https://github.com/stevearc/oil.nvim/issues/632) | Preview + move = copy                                      | fixed ([#12](https://github.com/barrettruth/canola.nvim/pull/12))                             |


### PR DESCRIPTION
## Problem

stevearc/oil.nvim#623 was marked not actionable as a cross-plugin issue, but oil's nonstandard buffer opening (`bufadd` + manual `buflisted` + `vim.cmd.buffer()`) may be the root cause.

## Solution

Revert status to open for further investigation.