### PR TITLE
docs(upstream): mark #431 as duplicate of #525

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -75,7 +75,7 @@ issues against this fork.
 | [#399](https://github.com/stevearc/oil.nvim/issues/399) | Open file without closing Oil                              | open                                                                                          |
 | [#404](https://github.com/stevearc/oil.nvim/issues/404) | Restricted UNC paths                                       | not actionable — Windows-only                                                                 |
 | [#416](https://github.com/stevearc/oil.nvim/issues/416) | Cannot remap key to open split                             | open                                                                                          |
-| [#431](https://github.com/stevearc/oil.nvim/issues/431) | More SSH adapter documentation                             | open                                                                                          |
+| [#431](https://github.com/stevearc/oil.nvim/issues/431) | More SSH adapter documentation                             | duplicate of [#525](https://github.com/stevearc/oil.nvim/issues/525)                          |
 | [#435](https://github.com/stevearc/oil.nvim/issues/435) | Error previewing with semantic tokens LSP                  | fixed — cherry-picked ([#467](https://github.com/stevearc/oil.nvim/pull/467))                 |
 | [#436](https://github.com/stevearc/oil.nvim/issues/436) | Owner and group columns                                    | open                                                                                          |
 | [#444](https://github.com/stevearc/oil.nvim/issues/444) | Opening behaviour customization                            | open                                                                                          |


### PR DESCRIPTION
## Problem

Upstream issue stevearc/oil.nvim#431 (SSH adapter documentation) is a duplicate of stevearc/oil.nvim#525 which covers the same request with more detail.

## Solution

Mark as duplicate of #525.