### PR TITLE
feat(api): add `get_current_url()` for adapter-agnostic URL access

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -395,7 +395,17 @@ toggle_hidden()                                                *canola.toggle_hi
 
 
 get_current_dir({bufnr}): nil|string                         *canola.get_current_dir*
-    Get the current directory
+    Get the current directory as a local filesystem path. Returns nil for
+    non-local adapters (SSH, S3, trash). See |canola.get_current_url| for an
+    adapter-agnostic alternative.
+
+    Parameters:
+      {bufnr} `nil|integer`
+
+get_current_url({bufnr}): nil|string                         *canola.get_current_url*
+    Get the current buffer's canola URL (e.g. "canola:///path/" or
+    "canola-ssh://host/path/"). Works for all adapters. Returns nil if the
+    buffer is not a canola buffer.
 
     Parameters:
       {bufnr} `nil|integer`

--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -114,7 +114,7 @@ issues against this fork.
 | [#641](https://github.com/stevearc/oil.nvim/issues/641) | Flicker on `actions.parent`                                | open                                                                                          |
 | [#642](https://github.com/stevearc/oil.nvim/issues/642) | W10 warning under `nvim -R`                                | fixed                                                                                         |
 | [#645](https://github.com/stevearc/oil.nvim/issues/645) | `close_float` action                                       | fixed                                                                                         |
-| [#646](https://github.com/stevearc/oil.nvim/issues/646) | `get_current_dir` nil on SSH                               | open                                                                                          |
+| [#646](https://github.com/stevearc/oil.nvim/issues/646) | `get_current_dir` nil on SSH                               | fixed — `get_current_url()` API                                                               |
 | [#650](https://github.com/stevearc/oil.nvim/issues/650) | LSP `workspace.fileOperations` events                      | fixed                                                                                         |
 | [#655](https://github.com/stevearc/oil.nvim/issues/655) | File statistics as virtual text                            | open                                                                                          |
 | [#659](https://github.com/stevearc/oil.nvim/issues/659) | Mark and diff files in buffer                              | open                                                                                          |

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -154,6 +154,19 @@ M.get_current_dir = function(bufnr)
   end
 end
 
+---Get the current buffer's canola URL (e.g. "canola:///path/" or "canola-ssh://host/path/")
+---@param bufnr? integer
+---@return nil|string
+M.get_current_url = function(bufnr)
+  local config = require('canola.config')
+  local util = require('canola.util')
+  local buf_name = vim.api.nvim_buf_get_name(bufnr or 0)
+  local scheme = util.parse_url(buf_name)
+  if scheme and config.adapters[scheme] then
+    return buf_name
+  end
+end
+
 ---Get the canola url for a given directory
 ---@private
 ---@param dir nil|string When nil, use the cwd


### PR DESCRIPTION
## Problem

`get_current_dir()` returns nil for non-local adapters (SSH, S3, trash), leaving users with no public API to get the current buffer's location. Addresses stevearc/oil.nvim#646.

## Solution

Add `get_current_url()` which returns the full canola URL (e.g. `canola-ssh://host/path/`) for any adapter, or nil if not in a canola buffer. Updated vimdoc for both `get_current_dir` and `get_current_url`.