### PR TITLE
fix(test): resolve trash_spec.lua flakes from leaked mutation state

### DIFF
--- a/lua/oil/mutator/init.lua
+++ b/lua/oil/mutator/init.lua
@@ -510,6 +510,10 @@ M.is_mutating = function()
   return mutation_in_progress
 end
 
+M.reset = function()
+  mutation_in_progress = false
+end
+
 ---@param confirm nil|boolean
 ---@param cb? fun(err: nil|string)
 M.try_write_changes = function(confirm, cb)

--- a/spec/test_util.lua
+++ b/spec/test_util.lua
@@ -17,6 +17,14 @@ M.reset_editor = function()
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end
+  local mutator = require('oil.mutator')
+  if mutator.is_mutating() then
+    vim.wait(50, function()
+      return not mutator.is_mutating()
+    end, 10)
+    mutator.reset()
+    require('oil.view').unlock_buffers()
+  end
   cache.clear_everything()
   test_adapter.test_clear()
 end


### PR DESCRIPTION
## Problem

`mutation_in_progress` and `buffers_locked` are module-level locals in `mutator/init.lua` and `view.lua`. When a trash test times out mid-mutation, these flags leak into subsequent tests. The next test's `save()` silently bails on `mutation_in_progress`, `OilMutationComplete` never fires, and the entire remainder of the suite cascades with 10s timeouts.

Baseline pass rate: 4/10 sequential runs.

## Solution

Expose `mutator.reset()` to clear leaked mutation state. Call it from `reset_editor()` when `is_mutating()` is true, preceded by a 50ms event loop drain so in-flight libuv callbacks settle first. Zero overhead on the happy path.

After fix: 49/50 parallel runs pass (~2.4s per run, unchanged).

Closes #158