### PR TITLE
fix(view): reapply column highlights after paste and buffer edits

### DIFF
--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -547,8 +547,12 @@ M.reapply_highlights = function(bufnr)
   end
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local scheme = util.parse_url(bufname)
+  if not scheme then
+    return
+  end
   local column_defs = columns.get_supported_columns(scheme)
   local col_width = vim.deepcopy(sess.col_width)
+  ---@cast col_width integer[]
   local col_align = sess.col_align
   local buf_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
   local line_table = {}


### PR DESCRIPTION
## Problem

Column extmarks (icon color, per-character permissions highlights) are
only applied during `render_buffer`. Neovim does not copy extmarks on
yank/paste, so lines inserted via `yyp` or `p` render without any
column highlights.

## Solution

Store `col_width` and `col_align` in `session[bufnr]` after each
render. Add `M.reapply_highlights` which re-parses all buffer lines,
reconstructs the column chunk table, and re-applies extmarks via
`util.set_highlights`. Wire it to a `TextChanged` autocmd, guarded by
`_rendering[bufnr]` to skip oil's own `nvim_buf_set_lines` calls.