### PR TITLE
fix(ftp): remove deleted mode_to_highlights call, add owner/group columns

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -650,10 +650,10 @@ permissions                                                   *column-permission
       {align}     `"left"|"center"|"right"` Text alignment within the column
 
 owner                                                               *column-owner*
-    Adapters: files, ssh
+    Adapters: files, ssh, ftp
     Display-only: this column is read-only
     The file owner. On local files, resolves UID to username via /etc/passwd.
-    On SSH, displays the numeric UID from `ls -lan`.
+    On SSH and FTP, displays the value from the directory listing.
 
     Parameters:
       {highlight} `string|fun(value: string): string` Highlight group, or
@@ -661,10 +661,10 @@ owner                                                               *column-owne
       {align}     `"left"|"center"|"right"` Text alignment within the column
 
 group                                                               *column-group*
-    Adapters: files, ssh
+    Adapters: files, ssh, ftp
     Display-only: this column is read-only
     The file group. On local files, resolves GID to group name via /etc/group.
-    On SSH, displays the numeric GID from `ls -lan`.
+    On SSH and FTP, displays the value from the directory listing.
 
     Parameters:
       {highlight} `string|fun(value: string): string` Highlight group, or
@@ -1023,6 +1023,10 @@ SSH                                                              *oil-adapter-ss
     The underlying `ssh` command respects `~/.ssh/config`, so per-host
     settings like `IdentityFile`, `ProxyJump`, and `Port` work as expected.
 
+    The adapter supports the `size`, `permissions`, `owner`, and `group`
+    columns. Permission changes use `chmod` on the remote host. The
+    `owner` and `group` columns display numeric UIDs/GIDs from `ls -lan`.
+
     Limitations ~
 
     The SSH adapter is self-contained. It does not expose a mount point or
@@ -1052,6 +1056,8 @@ S3                                                                *oil-adapter-s
 <
     Older versions of Neovim (0.11 and earlier) don't support numbers in the
     URL scheme, so use `oil-sss` instead of `oil-s3`.
+
+    The adapter supports the `size` and `birthtime` columns.
 
 FTP                                                              *oil-adapter-ftp*
 
@@ -1092,9 +1098,10 @@ FTP                                                              *oil-adapter-ft
           extra_curl_args = { "--insecure" },
         })
 <
-    The adapter supports the `size`, `mtime`, and `permissions` columns.
-    Permission changes use the FTP `SITE CHMOD` command; not all servers
-    support it.
+    The adapter supports the `size`, `mtime`, `permissions`, `owner`, and
+    `group` columns. Permission changes use the FTP `SITE CHMOD` command;
+    not all servers support it. The `owner` and `group` columns are only
+    available on servers that return Unix-style directory listings.
 
     Dependencies ~
 

--- a/lua/oil/adapters/ftp.lua
+++ b/lua/oil/adapters/ftp.lua
@@ -217,8 +217,8 @@ local month_map = {
 ---@param line string
 ---@return nil|string, nil|string, nil|table
 local function parse_unix_list_line(line)
-  local perms, size, month, day, timeoryear, name =
-    line:match('^([dlrwxstST%-]+)%s+%d+%s+%S+%s+%S+%s+(%d+)%s+(%a+)%s+(%d+)%s+(%S+)%s+(.+)$')
+  local perms, user, group, size, month, day, timeoryear, name =
+    line:match('^([dlrwxstST%-]+)%s+%d+%s+(%S+)%s+(%S+)%s+(%d+)%s+(%a+)%s+(%d+)%s+(%S+)%s+(.+)$')
   if not perms then
     return nil
   end
@@ -280,7 +280,7 @@ local function parse_unix_list_line(line)
     end
   end
   local mode = permissions.parse(perms:sub(2))
-  local meta = { size = tonumber(size), mtime = mtime, mode = mode }
+  local meta = { user = user, group = group, size = tonumber(size), mtime = mtime, mode = mode }
   if link_target then
     meta.link = link_target
   end
@@ -369,8 +369,7 @@ ftp_columns.permissions = {
     if not meta or not meta.mode then
       return
     end
-    local str = permissions.mode_to_str(meta.mode)
-    return { str, permissions.mode_to_highlights(str) }
+    return permissions.mode_to_str(meta.mode)
   end,
 
   parse = function(line, conf)
@@ -402,6 +401,34 @@ ftp_columns.permissions = {
       { string.format('ftp.voidcmd(%q)', 'SITE CHMOD ' .. octal .. ' ' .. ftp_path) },
       callback
     )
+  end,
+}
+
+ftp_columns.owner = {
+  render = function(entry, conf)
+    local meta = entry[FIELD_META]
+    if not meta or not meta.user then
+      return ''
+    end
+    return meta.user
+  end,
+
+  parse = function(line, conf)
+    return line:match('^(%S+)%s+(.*)$')
+  end,
+}
+
+ftp_columns.group = {
+  render = function(entry, conf)
+    local meta = entry[FIELD_META]
+    if not meta or not meta.group then
+      return ''
+    end
+    return meta.group
+  end,
+
+  parse = function(line, conf)
+    return line:match('^(%S+)%s+(.*)$')
   end,
 }
 


### PR DESCRIPTION
## Problem

PR #186 removed `permissions.mode_to_highlights()` from `permissions.lua`
but missed the call site in `ftp.lua:373`, causing a runtime crash for
FTP users with the permissions column enabled. Additionally, the FTP
`parse_unix_list_line` function parsed user/group fields from `ls` output
but discarded them.

## Solution

Revert the FTP permissions render to return a plain string. Capture user
and group in `parse_unix_list_line`, store in entry meta, and expose as
display-only `owner`/`group` columns. Update vimdoc to list supported
columns for the SSH, S3, and FTP adapter sections.