### PR TITLE
fix(ssh): use POSIX case instead of bash [[ in realpath fallback

### DIFF
--- a/lua/oil/adapters/ssh/sshfs.lua
+++ b/lua/oil/adapters/ssh/sshfs.lua
@@ -103,7 +103,7 @@ end
 
 function SSHFS:realpath(path, callback)
   local cmd = string.format(
-    'if ! readlink -f "%s" 2>/dev/null; then [[ "%s" == /* ]] && echo "%s" || echo "$PWD/%s"; fi',
+    'if ! readlink -f "%s" 2>/dev/null; then case "%s" in /*) echo "%s";; *) echo "$PWD/%s";; esac; fi',
     path,
     path,
     path,


### PR DESCRIPTION
## Problem

The `realpath` fallback in `sshfs.lua` used `[[ "$path" == /* ]]` which
is a bash-ism. On systems where `/bin/sh` is dash (e.g. NixOS), this
fails with `[[: not found`.

## Solution

Replace the `[[ ... ]]` test with a POSIX `case` statement that works
in any `/bin/sh`.