### PR TITLE
fix(session): clear buftype on VimLeavePre so mksession saves oil URLs

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1591,6 +1591,19 @@ M.setup = function(opts)
       end
     end,
   })
+  vim.api.nvim_create_autocmd('VimLeavePre', {
+    desc = 'Clear buftype on oil buffers so mksession saves their URLs',
+    group = aug,
+    pattern = '*',
+    callback = function()
+      local util = require('oil.util')
+      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_valid(bufnr) and util.is_oil_bufnr(bufnr) then
+          vim.bo[bufnr].buftype = ''
+        end
+      end
+    end,
+  })
 
   if config.default_to_float then
     vim.api.nvim_create_autocmd('VimEnter', {


### PR DESCRIPTION
## Problem

`mksession` treats `buftype='acwrite'` buffers as blank windows when `blank` is excluded from `sessionoptions`, silently omitting oil windows from saved sessions. Affects all session plugins that auto-save on exit (persistence.nvim, auto-session, etc.).

## Solution

Register a `VimLeavePre` autocmd that clears `buftype` on all oil buffers before Neovim exits. The session writer then sees them as regular file buffers and saves their `oil://` URLs. On restore, canola's `BufReadCmd` handler re-initializes them normally.

Mid-session `:mksession` calls are not yet covered — that requires a `SessionWritePre` event tracked at neovim/neovim#22814.

Closes #149

## Consolidates

- stevearc/oil.nvim#232
- stevearc/oil.nvim#664
- stevearc/oil.nvim#678