### PR TITLE
docs: rewrite README for v1.0 launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `:help canola.nvim` for full documentation.
 ## Requirements
 
 - Neovim 0.10+
-- (Optional) icon provider:
+- (Optionally) an icon provider:
   [mini.icons](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-icons.md),
   [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons), or
   [nonicons.nvim](https://github.com/barrettruth/nonicons.nvim)


### PR DESCRIPTION
## Problem

README contained a generic oil.nvim feature list, a broken migration FAQ referencing unimplemented `vim.g.canola`, and a typo in the repo slug (`barretruth`).

## Solution

Rewrite around the v1.0 thesis — drop-in replacement with 55+ upstream issues resolved. Clean migration section, link to `doc/upstream.md`, remove incorrect config advice.

Partial progress on #33 — video script still TBD.