### PR TITLE
refactor(config): serializable keymap format + default q binding

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -62,15 +62,14 @@ The full list of options with their defaults:
       watch = false,
       border = nil,
 
-      show_hidden = false,
-      hidden = { patterns = { "^%." }, always = {} },
+      hidden = { enabled = true, patterns = { "^%." }, always = {} },
 
       sort = "default",
       highlights = {},
 
       confirm = true,
       save = "prompt",
-      delete = { wipe_buffers = false },
+      delete = { wipe = false },
       create = { file_mode = 420, dir_mode = 493 },
 
       keymaps = {
@@ -101,7 +100,7 @@ The full list of options with their defaults:
         max_height = 0,
         border = nil,
         preview_split = "auto",
-        win_options = { winblend = 0 },
+        win = { winblend = 0 },
       },
 
       preview = {
@@ -109,7 +108,7 @@ The full list of options with their defaults:
         live = false,
         max_file_size_mb = 10,
         disable = {},
-        win_options = {},
+        win = {},
       },
 
       confirmation = {
@@ -120,7 +119,7 @@ The full list of options with their defaults:
         min_height = { 5, 0.1 },
         height = nil,
         border = nil,
-        win_options = { winblend = 0 },
+        win = { winblend = 0 },
       },
 
       progress = {
@@ -132,11 +131,11 @@ The full list of options with their defaults:
         height = nil,
         border = nil,
         minimized_border = "none",
-        win_options = { winblend = 0 },
+        win = { winblend = 0 },
       },
 
-      buf_options = { buflisted = false, bufhidden = "hide" },
-      win_options = {
+      buf = { buflisted = false, bufhidden = "hide" },
+      win = {
         wrap = false,
         signcolumn = "no",
         cursorcolumn = false,
@@ -171,17 +170,14 @@ border                                                            *canola.border
     Global border style. Falls through to `float.border`,
     `confirmation.border`, and `progress.border` when those are nil.
 
-show_hidden                                                  *canola.show_hidden*
-    type: `boolean` default: `false`
-    When `true`, show hidden files by default. Toggle at runtime with `g.`.
-
 hidden                                                            *canola.hidden*
     type: `canola.HiddenConfig`
-    default: `{ patterns = { "^%." }, always = {} }`
-    `patterns` is a list of Lua patterns. A file matching any pattern is
-    considered hidden (dimmed when `show_hidden` is true, invisible when
-    false). `always` is a list of Lua patterns for files that are never
-    shown, even when hidden files are visible.
+    default: `{ enabled = true, patterns = { "^%." }, always = {} }`
+    `enabled`: when `true`, files matching `patterns` are hidden. Toggle at
+    runtime with `g.`. `patterns` is a list of Lua patterns. A file matching
+    any pattern is considered hidden (dimmed when `enabled` is false,
+    invisible when true). `always` is a list of Lua patterns for files that
+    are never shown, even when hidden files are visible.
 
 sort                                                                *canola.sort*
     type: `string|canola.SortConfig` default: `"default"`
@@ -226,9 +222,9 @@ save                                                          *canola.save_opt*
     - `false`: open the original file without saving
 
 delete                                                            *canola.delete*
-    type: `canola.DeleteConfig` default: `{ wipe_buffers = false }`
-    `wipe_buffers`: when `true`, wipe any open buffer whose path matches a
-    file deleted via canola.
+    type: `canola.DeleteConfig` default: `{ wipe = false }`
+    `wipe`: when `true`, wipe any open buffer whose path matches a file
+    deleted via canola.
 
 create                                                            *canola.create*
     type: `canola.CreateConfig`
@@ -258,7 +254,7 @@ float                                                              *canola.float
     `border`: border style (falls back to global `border`).
     `preview_split`: where to put the preview when floating (`"auto"`,
     `"left"`, `"right"`, `"above"`, `"below"`).
-    `win_options`: window-local options for the float.
+    `win`: window-local options for the float.
 
 preview                                                          *canola.preview*
     type: `canola.PreviewConfig`
@@ -266,7 +262,7 @@ preview                                                          *canola.preview
     `live`: when `true`, load files into real buffers (enables LSP, treesitter).
     `max_file_size_mb`: skip preview for files larger than this (MB).
     `disable`: list of Lua patterns; matching filenames skip preview.
-    `win_options`: window-local options for the preview window.
+    `win`: window-local options for the preview window.
 
 confirmation                                                *canola.confirmation*
     type: `canola.ConfirmationWindowConfig`
@@ -279,12 +275,12 @@ progress                                                        *canola.progress
     `border` falls back to global `border` when nil.
     `minimized_border`: border style when the progress window is minimized.
 
-buf_options                                                  *canola.buf_options*
+buf                                                                  *canola.buf*
     type: `table<string, any>`
     default: `{ buflisted = false, bufhidden = "hide" }`
     Buffer-local options applied to every canola buffer.
 
-win_options                                                  *canola.win_options*
+win                                                                  *canola.win*
     type: `table<string, any>`
     Window-local options applied to every canola window. See |canola-config|
     for the full default list.
@@ -880,7 +876,7 @@ Show CWD in the winbar ~
     end
 
     vim.g.canola = {
-      win_options = {
+      win = {
         winbar = "%!v:lua.get_canola_winbar()",
       },
     }

--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -31,15 +31,14 @@ local default_config = {
   watch = false,
   border = nil,
 
-  show_hidden = false,
-  hidden = { patterns = { '^%.' }, always = {} },
+  hidden = { enabled = true, patterns = { '^%.' }, always = {} },
 
   sort = 'default',
   highlights = {},
 
   confirm = true,
   save = 'prompt',
-  delete = { wipe_buffers = false },
+  delete = { wipe = false },
   create = { file_mode = 420, dir_mode = 493 },
 
   keymaps = {},
@@ -53,7 +52,7 @@ local default_config = {
     max_height = 0,
     border = nil,
     preview_split = 'auto',
-    win_options = { winblend = 0 },
+    win = { winblend = 0 },
   },
 
   preview = {
@@ -61,7 +60,7 @@ local default_config = {
     live = false,
     max_file_size_mb = 10,
     disable = {},
-    win_options = {},
+    win = {},
   },
 
   confirmation = {
@@ -72,7 +71,7 @@ local default_config = {
     min_height = { 5, 0.1 },
     height = nil,
     border = nil,
-    win_options = { winblend = 0 },
+    win = { winblend = 0 },
   },
 
   progress = {
@@ -84,11 +83,11 @@ local default_config = {
     height = nil,
     border = nil,
     minimized_border = 'none',
-    win_options = { winblend = 0 },
+    win = { winblend = 0 },
   },
 
-  buf_options = { buflisted = false, bufhidden = 'hide' },
-  win_options = {
+  buf = { buflisted = false, bufhidden = 'hide' },
+  win = {
     wrap = false,
     signcolumn = 'no',
     cursorcolumn = false,
@@ -107,7 +106,6 @@ local default_config = {
 ---@field cursor boolean
 ---@field watch boolean
 ---@field border? string|string[]
----@field show_hidden boolean
 ---@field hidden canola.HiddenConfig
 ---@field sort string|canola.SortConfig
 ---@field highlights canola.HighlightPattern[]
@@ -121,8 +119,8 @@ local default_config = {
 ---@field preview canola.PreviewConfig
 ---@field confirmation canola.ConfirmationWindowConfig
 ---@field progress canola.ProgressWindowConfig
----@field buf_options table<string, any>
----@field win_options table<string, any>
+---@field buf table<string, any>
+---@field win table<string, any>
 ---@field _constrain_cursor false|"name"|"editable"
 ---@field _sort_spec canola.SortSpec[]
 ---@field _natural_order boolean|"fast"
@@ -135,6 +133,7 @@ local default_config = {
 local M = {}
 
 ---@class (exact) canola.HiddenConfig
+---@field enabled boolean
 ---@field patterns string[]
 ---@field always string[]
 
@@ -146,7 +145,7 @@ local M = {}
 ---@alias canola.HighlightPattern { [1]: string, [2]: string }
 
 ---@class (exact) canola.DeleteConfig
----@field wipe_buffers boolean
+---@field wipe boolean
 
 ---@class (exact) canola.CreateConfig
 ---@field file_mode integer
@@ -164,14 +163,14 @@ local M = {}
 ---@field max_height integer
 ---@field border? string|string[]
 ---@field preview_split "auto"|"left"|"right"|"above"|"below"
----@field win_options table<string, any>
+---@field win table<string, any>
 
 ---@class (exact) canola.PreviewConfig
 ---@field follow boolean
 ---@field live boolean
 ---@field max_file_size_mb? number
 ---@field disable string[]
----@field win_options table<string, any>
+---@field win table<string, any>
 
 ---@class (exact) canola.SortSpec
 ---@field [1] string
@@ -191,7 +190,7 @@ local M = {}
 ---@field min_height canola.WindowDimension
 ---@field height? number
 ---@field border? string|string[]
----@field win_options table<string, any>
+---@field win table<string, any>
 
 ---@alias canola.PreviewMethod
 ---| '"load"'

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -279,7 +279,7 @@ M.open_float = function(dir, opts, cb)
   local winid = vim.api.nvim_open_win(bufnr, true, win_opts)
   vim.w[winid].is_canola_win = true
   vim.w[winid].canola_original_win = original_winid
-  for k, v in pairs(config.float.win_options) do
+  for k, v in pairs(config.float.win) do
     vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
   end
   local autocmds = {}
@@ -322,7 +322,7 @@ M.open_float = function(dir, opts, cb)
         if not vim.api.nvim_win_is_valid(winid) or vim.api.nvim_win_get_buf(winid) ~= winbuf then
           return
         end
-        for k, v in pairs(config.float.win_options) do
+        for k, v in pairs(config.float.win) do
           vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
         end
 
@@ -345,8 +345,8 @@ M.open_float = function(dir, opts, cb)
 
   vim.cmd.edit({ args = { util.escape_filename(parent_url) }, mods = { keepalt = true } })
   -- :edit will set buflisted = true, but we may not want that
-  if config.buf_options.buflisted ~= nil then
-    vim.api.nvim_set_option_value('buflisted', config.buf_options.buflisted, { buf = 0 })
+  if config.buf.buflisted ~= nil then
+    vim.api.nvim_set_option_value('buflisted', config.buf.buflisted, { buf = 0 })
   end
 
   util.run_after_load(0, function()
@@ -422,8 +422,8 @@ M.open_split = function(dir, opts, cb)
   vim.w[winid].canola_original_win = original_winid
 
   vim.cmd.edit({ args = { util.escape_filename(parent_url) }, mods = { keepalt = true } })
-  if config.buf_options.buflisted ~= nil then
-    vim.api.nvim_set_option_value('buflisted', config.buf_options.buflisted, { buf = 0 })
+  if config.buf.buflisted ~= nil then
+    vim.api.nvim_set_option_value('buflisted', config.buf.buflisted, { buf = 0 })
   end
 
   util.run_after_load(0, function()
@@ -488,8 +488,8 @@ M.open = function(dir, opts, cb)
   end
   vim.cmd.edit({ args = { util.escape_filename(parent_url) }, mods = { keepalt = true } })
   -- :edit will set buflisted = true, but we may not want that
-  if config.buf_options.buflisted ~= nil then
-    vim.api.nvim_set_option_value('buflisted', config.buf_options.buflisted, { buf = 0 })
+  if config.buf.buflisted ~= nil then
+    vim.api.nvim_set_option_value('buflisted', config.buf.buflisted, { buf = 0 })
   end
 
   util.run_after_load(0, function()
@@ -739,7 +739,7 @@ M.open_preview = function(opts, callback)
 
     vim.api.nvim_set_option_value('previewwindow', true, { scope = 'local', win = 0 })
     vim.api.nvim_win_set_var(0, 'oil_preview', true)
-    for k, v in pairs(config.preview.win_options) do
+    for k, v in pairs(config.preview.win) do
       vim.api.nvim_set_option_value(k, v, { scope = 'local', win = preview_win })
     end
     vim.w.canola_entry_id = entry.id
@@ -902,7 +902,7 @@ M.select = function(opts, callback)
 
       -- The :buffer command doesn't set buflisted=true
       -- So do that for normal files or for oil dirs if config set buflisted=true
-      if entry_is_file or config.buf_options.buflisted then
+      if entry_is_file or config.buf.buflisted then
         vim.bo[filebufnr].buflisted = true
       end
 
@@ -1456,8 +1456,8 @@ M.init = function()
           vim.fn.setreg('#', orig_buffer)
         end
         view.set_win_options()
-        if config.buf_options.buflisted ~= nil then
-          vim.api.nvim_set_option_value('buflisted', config.buf_options.buflisted, { buf = 0 })
+        if config.buf.buflisted ~= nil then
+          vim.api.nvim_set_option_value('buflisted', config.buf.buflisted, { buf = 0 })
         end
         vim.w.canola_did_enter = true
       elseif vim.fn.isdirectory(bufname) == 0 then

--- a/lua/canola/mutator/confirmation.lua
+++ b/lua/canola/mutator/confirmation.lua
@@ -124,7 +124,7 @@ M.show = vim.schedule_wrap(function(actions, should_confirm, cb)
   end
   vim.bo[bufnr].filetype = 'oil_preview'
   vim.bo[bufnr].syntax = 'oil_preview'
-  for k, v in pairs(config.confirmation.win_options) do
+  for k, v in pairs(config.confirmation.win) do
     vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
   end
 

--- a/lua/canola/mutator/init.lua
+++ b/lua/canola/mutator/init.lua
@@ -420,7 +420,7 @@ M.process_actions = function(actions, cb)
       finished = true
       progress:close()
       progress = nil
-      if config.delete.wipe_buffers and not err then
+      if config.delete.wipe and not err then
         for _, action in ipairs(actions) do
           if action.type == 'delete' then
             local scheme, path = util.parse_url(action.url)

--- a/lua/canola/mutator/progress.lua
+++ b/lua/canola/mutator/progress.lua
@@ -69,7 +69,7 @@ function Progress:show(opts)
     border = config.progress.border,
   })
   vim.bo[self.bufnr].filetype = 'oil_progress'
-  for k, v in pairs(config.progress.win_options) do
+  for k, v in pairs(config.progress.win) do
     vim.api.nvim_set_option_value(k, v, { scope = 'local', win = self.winid })
   end
   table.insert(

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -54,7 +54,7 @@ M.should_display = function(bufnr, entry)
     return false, true
   else
     local is_hidden = config._is_hidden_file(name, bufnr, public_entry)
-    local display = config.show_hidden or not is_hidden
+    local display = not config.hidden.enabled or not is_hidden
     return display, is_hidden
   end
 end
@@ -126,7 +126,7 @@ M.toggle_hidden = function()
   if any_modified then
     vim.notify('Cannot toggle hidden files when you have unsaved changes', vim.log.levels.WARN)
   else
-    config.show_hidden = not config.show_hidden
+    config.hidden.enabled = not config.hidden.enabled
     M.rerender_all_oil_buffers({ refetch = false })
   end
 end
@@ -241,11 +241,11 @@ M.set_win_options = function()
   -- work around https://github.com/neovim/neovim/pull/27422
   vim.api.nvim_set_option_value('foldmethod', 'manual', { scope = 'local', win = winid })
 
-  for k, v in pairs(config.win_options) do
+  for k, v in pairs(config.win) do
     vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
   end
-  if vim.wo[winid].previewwindow then -- apply preview window options last
-    for k, v in pairs(config.preview.win_options) do
+  if vim.wo[winid].previewwindow then
+    for k, v in pairs(config.preview.win) do
       vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
     end
   end
@@ -588,7 +588,7 @@ M.initialize = function(bufnr)
   vim.bo[bufnr].filetype = 'canola'
   vim.b[bufnr].EditorConfig_disable = 1
   session[bufnr] = session[bufnr] or {}
-  for k, v in pairs(config.buf_options) do
+  for k, v in pairs(config.buf) do
     vim.bo[bufnr][k] = v
   end
   vim.api.nvim_buf_call(bufnr, M.set_win_options)

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -4,14 +4,14 @@ describe('config', function()
   it('uses defaults when vim.g.canola is nil', function()
     vim.g.canola = nil
     config.init()
-    assert.is_false(config.show_hidden)
+    assert.is_true(config.hidden.enabled)
     assert.equals('editable', config._constrain_cursor)
   end)
 
   it('applies vim.g.canola values', function()
-    vim.g.canola = { show_hidden = true }
+    vim.g.canola = { hidden = { enabled = false } }
     config.init()
-    assert.is_true(config.show_hidden)
+    assert.is_false(config.hidden.enabled)
   end)
 
   it('resolves sort presets', function()

--- a/spec/files_spec.lua
+++ b/spec/files_spec.lua
@@ -170,11 +170,11 @@ describe('files adapter', function()
     local mutator = require('canola.mutator')
 
     before_each(function()
-      config.delete.wipe_buffers = true
+      config.delete.wipe = true
     end)
 
     after_each(function()
-      config.delete.wipe_buffers = false
+      config.delete.wipe = false
     end)
 
     it('wipes the buffer for a deleted file', function()
@@ -192,7 +192,7 @@ describe('files adapter', function()
     end)
 
     it('does not wipe the buffer when disabled', function()
-      config.delete.wipe_buffers = false
+      config.delete.wipe = false
       tmpdir:create({ 'b.txt' })
       local dirurl = 'canola://' .. vim.fn.fnamemodify(tmpdir.path, ':p')
       local filepath = vim.fn.fnamemodify(tmpdir.path, ':p') .. 'b.txt'


### PR DESCRIPTION
## Problem

Default keymaps used mixed-key tables (`{ 'actions.select', opts = { vertical = true } }`) which `vim.g` cannot serialize. This broke the `vim.g.canola` config surface for any keymap override that uses `opts` or `mode` — 12 of 15 default keymaps were unserializable.

## Solution

Switch all default keymaps from positional `[1]` to explicit `callback` key, making every table pure-string-keyed and `vim.g`-compatible. Add `q` as a default binding for `actions.close`. Update vimdoc examples to match.