### PR TITLE
fix(config): disable extglob by default

### DIFF
--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -40,7 +40,7 @@ local default_config = {
   save = 'prompt',
   delete = { wipe = false },
   create = { file_mode = 420, dir_mode = 493 },
-  extglob = 1000,
+  extglob = false,
 
   keymaps = {},
 

--- a/spec/mutator_spec.lua
+++ b/spec/mutator_spec.lua
@@ -167,6 +167,11 @@ describe('mutator', function()
     end)
 
     describe('extglob', function()
+      before_each(function()
+        vim.g.canola = vim.tbl_deep_extend('force', vim.g.canola, { extglob = 1000 })
+        require('canola').init()
+      end)
+
       it('expands simple alternation on new file', function()
         vim.cmd.edit({ args = { 'canola-test:///foo/' } })
         local bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
## Problem

Brace expansion was enabled by default with `extglob = 1000`, which is surprising behavior for users who don't expect file creation patterns to be expanded automatically.

## Solution

Change the `extglob` default from `1000` to `false`. Users who want brace expansion must explicitly opt in. Mutator tests that exercise expansion now enable `extglob` in a `before_each` block.