### PR TITLE
feat(view): replace static extmarks with decoration provider

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -1462,7 +1462,9 @@ M.init = function()
   })
   local aug = vim.api.nvim_create_augroup('Canola', {})
 
-  require('canola.view').setup_cleanup_autocmd()
+  local view = require('canola.view')
+  view.setup_cleanup_autocmd()
+  view.setup_decoration_provider()
 
   vim.g.loaded_netrw = 1
   vim.g.loaded_netrwPlugin = 1
@@ -1570,7 +1572,6 @@ M.init = function()
       -- We want to filter out oil buffers that are not directories (i.e. ssh files)
       local is_oil_dir_or_unknown = (vim.bo.filetype == 'canola' or vim.bo.filetype == '')
       if is_canola_buf and is_oil_dir_or_unknown then
-        local view = require('canola.view')
         view.maybe_set_cursor()
         -- While we are in an oil buffer, set the alternate file to the buffer we were in prior to
         -- opening oil

--- a/lua/canola/util.lua
+++ b/lua/canola/util.lua
@@ -315,50 +315,24 @@ end
 ---@param col_width integer[]
 ---@param col_align? canola.ColumnAlign[]
 ---@return string[]
----@return any[][] List of highlights {group, lnum, col_start, col_end}
 M.render_table = function(lines, col_width, col_align)
   col_align = col_align or {}
   local str_lines = {}
-  local highlights = {}
   for _, cols in ipairs(lines) do
-    local col = 0
     local pieces = {}
     for i, chunk in ipairs(cols) do
-      local text, hl
+      local text
       if type(chunk) == 'table' then
         text = chunk[1]
-        hl = chunk[2]
       else
         text = chunk
       end
-
-      local unpadded_len = text:len()
-      local padding
-      text, padding = M.pad_align(text, col_width[i], col_align[i] or 'left')
-
+      text = M.pad_align(text, col_width[i], col_align[i] or 'left')
       table.insert(pieces, text)
-      if hl then
-        if type(hl) == 'table' then
-          -- hl has the form { [1]: hl_name, [2]: col_start, [3]: col_end }[]
-          -- Notice that col_start and col_end are relative position inside
-          -- that col, so we need to add the offset to them
-          for _, sub_hl in ipairs(hl) do
-            table.insert(highlights, {
-              sub_hl[1],
-              #str_lines,
-              col + padding + sub_hl[2],
-              col + padding + sub_hl[3],
-            })
-          end
-        else
-          table.insert(highlights, { hl, #str_lines, col + padding, col + padding + unpadded_len })
-        end
-      end
-      col = col + text:len() + 1
     end
     table.insert(str_lines, table.concat(pieces, ' '))
   end
-  return str_lines, highlights
+  return str_lines
 end
 
 ---@param bufnr integer

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -174,6 +174,9 @@ end
 local session = {}
 local _rendering = {}
 
+local decor_ns = vim.api.nvim_create_namespace('CanolaDecor')
+local decor_ctx = {}
+
 ---@type table<integer, { lnum: integer, min_col: integer }>
 local insert_boundary = {}
 
@@ -524,52 +527,6 @@ local function setup_insert_constraints(bufnr)
 end
 
 ---@param bufnr integer
-M.reapply_highlights = function(bufnr)
-  local sess = session[bufnr]
-  if not sess or not sess.col_width or not sess.col_align then
-    return
-  end
-  local parser = require('canola.mutator.parser')
-  local adapter = util.get_adapter(bufnr)
-  if not adapter then
-    return
-  end
-  local bufname = vim.api.nvim_buf_get_name(bufnr)
-  local scheme = util.parse_url(bufname)
-  if not scheme then
-    return
-  end
-  local column_defs = columns.get_supported_columns(scheme)
-  local col_width = vim.deepcopy(sess.col_width)
-  ---@cast col_width integer[]
-  local col_align = sess.col_align
-  local buf_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
-  local line_table = {}
-  for _, line in ipairs(buf_lines) do
-    local result = parser.parse_line(adapter, line, column_defs)
-    if result then
-      local entry
-      if result.data.id == 0 then
-        entry = { 0, '..', 'directory' }
-      else
-        entry = cache.get_entry_by_id(result.data.id)
-      end
-      if entry then
-        local _, is_hidden = M.should_display(bufnr, entry)
-        local cols = M.format_entry_cols(entry, column_defs, col_width, adapter, is_hidden, bufnr)
-        table.insert(line_table, cols)
-      else
-        table.insert(line_table, {})
-      end
-    else
-      table.insert(line_table, {})
-    end
-  end
-  local _, highlights = util.render_table(line_table, col_width, col_align)
-  util.set_highlights(bufnr, highlights)
-end
-
----@param bufnr integer
 M.initialize = function(bufnr)
   if bufnr == 0 then
     bufnr = vim.api.nvim_get_current_buf()
@@ -729,16 +686,6 @@ M.initialize = function(bufnr)
     session[bufnr].fs_event = fs_event
   end
 
-  vim.api.nvim_create_autocmd('TextChanged', {
-    desc = 'Reapply oil column highlights after buffer edits',
-    group = 'Canola',
-    buffer = bufnr,
-    callback = function()
-      if not _rendering[bufnr] then
-        M.reapply_highlights(bufnr)
-      end
-    end,
-  })
   M.render_buffer_async(bufnr, {}, function(err)
     if err then
       vim.notify(
@@ -810,6 +757,40 @@ local function get_sort_function(adapter, num_entries)
   end
 end
 
+local function compute_highlights_for_cols(cols, col_width, col_align, line_len)
+  local highlights = {}
+  local col = 0
+  for i, chunk in ipairs(cols) do
+    local text, hl
+    if type(chunk) == 'table' then
+      text = chunk[1]
+      hl = chunk[2]
+    else
+      text = chunk
+    end
+    local unpadded_len = #text
+    local padded_text, padding = util.pad_align(text, col_width[i], (col_align or {})[i] or 'left')
+    if hl then
+      local hl_end = col + padding + unpadded_len
+      if i == #cols and line_len then
+        hl_end = line_len
+      end
+      if type(hl) == 'table' then
+        for _, sub_hl in ipairs(hl) do
+          table.insert(
+            highlights,
+            { sub_hl[1], col + padding + sub_hl[2], col + padding + sub_hl[3] }
+          )
+        end
+      else
+        table.insert(highlights, { hl, col + padding, hl_end })
+      end
+    end
+    col = col + #padded_text + 1
+  end
+  return highlights
+end
+
 ---@param bufnr integer
 ---@param opts nil|table
 ---    jump boolean
@@ -876,14 +857,14 @@ local function render_buffer(bufnr, opts)
     end
   end
 
-  local lines, highlights = util.render_table(line_table, col_width, col_align)
+  local lines = util.render_table(line_table, col_width, col_align)
 
   _rendering[bufnr] = true
   vim.bo[bufnr].modifiable = true
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
   vim.bo[bufnr].modifiable = false
   vim.bo[bufnr].modified = false
-  util.set_highlights(bufnr, highlights)
+  vim.api.nvim_buf_clear_namespace(bufnr, vim.api.nvim_create_namespace('Canola'), 0, -1)
   _rendering[bufnr] = nil
   session[bufnr].col_width = col_width
   session[bufnr].col_align = col_align
@@ -1207,6 +1188,68 @@ M.render_buffer_async = function(bufnr, opts, caller_callback)
       finish()
     end
   end)
+end
+
+M.setup_decoration_provider = function()
+  vim.api.nvim_set_decoration_provider(decor_ns, {
+    on_start = function()
+      decor_ctx = {}
+      return true
+    end,
+    on_win = function(_, winid, bufnr, toprow, botrow)
+      local sess = session[bufnr]
+      if not sess or not sess.col_width or not sess.col_align then
+        return false
+      end
+      if decor_ctx[bufnr] then
+        return
+      end
+      local adapter = util.get_adapter(bufnr, true)
+      if not adapter then
+        return false
+      end
+      local bufname = vim.api.nvim_buf_get_name(bufnr)
+      local scheme = util.parse_url(bufname)
+      if not scheme then
+        return false
+      end
+      decor_ctx[bufnr] = {
+        adapter = adapter,
+        column_defs = columns.get_supported_columns(scheme),
+        col_width = sess.col_width,
+        col_align = sess.col_align,
+      }
+    end,
+    on_line = function(_, winid, bufnr, row)
+      local ctx = decor_ctx[bufnr]
+      if not ctx then
+        return
+      end
+      local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+      if not line or line == '' then
+        return
+      end
+      local id = tonumber(line:match('^/(%d+)'))
+      if not id then
+        return
+      end
+      local entry = id == 0 and { 0, '..', 'directory' } or cache.get_entry_by_id(id)
+      if not entry then
+        return
+      end
+      local _, is_hidden = M.should_display(bufnr, entry)
+      local cols =
+        M.format_entry_cols(entry, ctx.column_defs, ctx.col_width, ctx.adapter, is_hidden, bufnr)
+      local highlights = compute_highlights_for_cols(cols, ctx.col_width, ctx.col_align, #line)
+      for _, hl in ipairs(highlights) do
+        vim.api.nvim_buf_set_extmark(bufnr, decor_ns, row, hl[2], {
+          end_col = hl[3],
+          hl_group = hl[1],
+          ephemeral = true,
+        })
+      end
+    end,
+  })
 end
 
 return M


### PR DESCRIPTION
## Problem

When editing filenames in canola buffers (e.g. `cw` to rename), all highlights vanish — directory blue, executable green, icon colors, everything. They return only after `TextChanged` fires `reapply_highlights()`, which re-parses **every line** in the buffer. For a 500-file directory, that's 500 `parse_line` calls per keystroke.

## Solution

Register an `nvim_set_decoration_provider` with a `CanolaDecor` namespace that computes highlights ephemerally per visible line during redraw. The `on_win` callback caches adapter/column metadata per buffer, and `on_line` extracts the entry ID from the line prefix, looks up the entry in cache, and sets ephemeral extmarks via `compute_highlights_for_cols()`.

This replaces the static extmark system: `reapply_highlights()`, its `TextChanged` autocmd, and the highlight return value from `render_table()` are all removed. `set_highlights()` is retained for `render_text()` (error/info display). Highlights now survive mid-edit without flicker and only fire for visible lines — O(visible) instead of O(total).

Closes #129