### PR TITLE
fix(highlights): wire CanolaDate highlight into time columns

### DIFF
--- a/lua/canola/adapters/files.lua
+++ b/lua/canola/adapters/files.lua
@@ -234,7 +234,7 @@ for _, time_key in ipairs({ 'ctime', 'mtime', 'atime', 'birthtime' }) do
           ret = vim.fn.strftime('%b %d %H:%M', stat[time_key].sec)
         end
       end
-      return ret
+      return { ret, 'CanolaDate' }
     end,
 
     parse = function(line, conf)


### PR DESCRIPTION
## Problem

The `CanolaDate` highlight group was defined in `init.lua` but never referenced — time columns still returned plain strings with no highlight.

## Solution

Return `{ ret, 'CanolaDate' }` from the time column render function so dates render with the `CanolaDate` highlight (blue, matching eza's `Blue.normal()`).