### PR TITLE
fix(view): disable cindent/smartindent on canola buffers (#236)

### DIFF
--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -520,6 +520,9 @@ M.initialize = function(bufnr)
   vim.bo[bufnr].swapfile = false
   vim.bo[bufnr].syntax = 'canola'
   vim.bo[bufnr].filetype = 'canola'
+  vim.bo[bufnr].cindent = false
+  vim.bo[bufnr].smartindent = false
+  vim.bo[bufnr].indentexpr = ''
   vim.b[bufnr].EditorConfig_disable = 1
   session[bufnr] = session[bufnr] or {}
   for k, v in pairs(config.buf) do


### PR DESCRIPTION
## Problem

Pressing `o` on the last line of a canola buffer produced an erroneously indented newline. Buffer lines start with `/{id}` which triggers C-style indent rules when `cindent` or `smartindent` is enabled globally.

## Solution

Explicitly set `cindent = false`, `smartindent = false`, and `indentexpr = ''` on canola buffers during initialization. These indent mechanisms are meaningless for file manager buffers.