### PR TITLE
refactor(actions): replace show_help float with vimdoc (#240)

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -9,11 +9,12 @@ CONTENTS                                                            *canola-cont
   4. Options                                                     |canola-options|
   5. Api                                                             |canola-api|
   6. Columns                                                     |canola-columns|
-  7. Actions                                                     |canola-actions|
-  8. Highlights                                               |canola-highlights|
-  9. Adapters                                                   |canola-adapters|
-  10. Recipes                                                    |canola-recipes|
-  11. Events                                                      |canola-events|
+  7. Keymaps                                                     |canola-keymaps|
+  8. Actions                                                     |canola-actions|
+  9. Highlights                                               |canola-highlights|
+  10. Adapters                                                   |canola-adapters|
+  11. Recipes                                                    |canola-recipes|
+  12. Events                                                      |canola-events|
 
 --------------------------------------------------------------------------------
 INTRODUCTION                                                    *canola-introduction*
@@ -649,6 +650,30 @@ birthtime                                                       *column-birthtim
       {format}    `string` Format string (see :help strftime)
 
 --------------------------------------------------------------------------------
+KEYMAPS                                                              *canola-keymaps*
+
+Default keybindings in canola buffers. Override via `keymaps` in
+|canola-config|. Set a key to `false` to disable a default binding.
+
+    Key          Action                  Description ~
+    `g?`           show_help               Show this help
+    `<CR>`         select                  Open entry under cursor
+    `<C-s>`        select (vertical)       Open in vertical split
+    `<C-h>`        select (horizontal)     Open in horizontal split
+    `<C-t>`        select (tab)            Open in new tab
+    `<C-p>`        preview                 Toggle preview
+    `<C-c>`        close                   Close canola buffer
+    `<C-l>`        refresh                 Refresh directory listing
+    `-`            parent                  Navigate to parent directory
+    `_`            open_cwd                Open current working directory
+    `` ` ``        cd                      :cd to canola directory
+    `g~`           cd (tab)                :tcd to canola directory
+    `gs`           change_sort             Change sort order
+    `gx`           open_external           Open with system handler
+    `g.`           toggle_hidden           Toggle hidden files
+    `q`            close                   Close canola buffer
+
+--------------------------------------------------------------------------------
 ACTIONS                                                              *canola-actions*
 
 The `keymaps` key in |canola-config| accepts mappings using the same parameters
@@ -780,7 +805,7 @@ send_to_qflist                                            *actions.send_to_qflis
       {target} `"qflist"|"loclist"` The target list to send files to
 
 show_help                                                      *actions.show_help*
-    Show default keymaps
+    Open |canola-keymaps| in vimdoc
 
 toggle_hidden                                              *actions.toggle_hidden*
     Toggle hidden files and directories

--- a/lua/canola/actions.lua
+++ b/lua/canola/actions.lua
@@ -5,8 +5,7 @@ local M = {}
 
 M.show_help = {
   callback = function()
-    local config = require('canola.config')
-    require('canola.keymap_util').show_help(config.keymaps)
+    vim.cmd('help canola-keymaps')
   end,
   desc = 'Show default keymaps',
 }

--- a/lua/canola/keymap_util.lua
+++ b/lua/canola/keymap_util.lua
@@ -1,7 +1,5 @@
 local actions = require('canola.actions')
 local config = require('canola.config')
-local layout = require('canola.layout')
-local util = require('canola.util')
 local M = {}
 
 ---@param rhs string|table|fun()
@@ -70,97 +68,6 @@ M.set_keymaps = function(keymaps, bufnr)
       vim.keymap.set(mode or '', k, rhs, vim.tbl_extend('keep', { buffer = bufnr }, opts))
     end
   end
-end
-
----@param keymaps table<string, string|table|fun()>
-M.show_help = function(keymaps)
-  local rhs_to_lhs = {}
-  local lhs_to_all_lhs = {}
-  for k, rhs in pairs(keymaps) do
-    if rhs then
-      if rhs_to_lhs[rhs] then
-        local first_lhs = rhs_to_lhs[rhs]
-        table.insert(lhs_to_all_lhs[first_lhs], k)
-      else
-        rhs_to_lhs[rhs] = k
-        lhs_to_all_lhs[k] = { k }
-      end
-    end
-  end
-
-  local max_lhs = 1
-  local keymap_entries = {}
-  for k, rhs in pairs(keymaps) do
-    local all_lhs = lhs_to_all_lhs[k]
-    if all_lhs then
-      local _, opts = resolve(rhs)
-      local keystr = table.concat(all_lhs, '/')
-      max_lhs = math.max(max_lhs, vim.api.nvim_strwidth(keystr))
-      table.insert(keymap_entries, { str = keystr, all_lhs = all_lhs, desc = opts.desc or '' })
-    end
-  end
-  table.sort(keymap_entries, function(a, b)
-    return a.desc < b.desc
-  end)
-
-  local lines = {}
-  local highlights = {}
-  local max_line = 1
-  for _, entry in ipairs(keymap_entries) do
-    local line = string.format(' %s   %s', util.pad_align(entry.str, max_lhs, 'left'), entry.desc)
-    max_line = math.max(max_line, vim.api.nvim_strwidth(line))
-    table.insert(lines, line)
-    local start = 1
-    for _, key in ipairs(entry.all_lhs) do
-      local keywidth = vim.api.nvim_strwidth(key)
-      table.insert(highlights, { 'Special', #lines, start, start + keywidth })
-      start = start + keywidth + 1
-    end
-  end
-
-  local bufnr = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
-  local ns = vim.api.nvim_create_namespace('Canola')
-  for _, hl in ipairs(highlights) do
-    local hl_group, lnum, start_col, end_col = unpack(hl)
-    vim.api.nvim_buf_set_extmark(bufnr, ns, lnum - 1, start_col, {
-      end_col = end_col,
-      hl_group = hl_group,
-    })
-  end
-  vim.keymap.set('n', 'q', '<cmd>close<CR>', { buffer = bufnr })
-  vim.keymap.set('n', '<c-c>', '<cmd>close<CR>', { buffer = bufnr })
-  vim.bo[bufnr].modifiable = false
-  vim.bo[bufnr].bufhidden = 'wipe'
-
-  local editor_width = vim.o.columns
-  local editor_height = layout.get_editor_height()
-  local winid = vim.api.nvim_open_win(bufnr, true, {
-    relative = 'editor',
-    row = math.max(0, (editor_height - #lines) / 2),
-    col = math.max(0, (editor_width - max_line - 1) / 2),
-    width = math.min(editor_width, max_line + 1),
-    height = math.min(editor_height, #lines),
-    zindex = 150,
-    style = 'minimal',
-    border = config.border,
-  })
-  local function close()
-    if vim.api.nvim_win_is_valid(winid) then
-      vim.api.nvim_win_close(winid, true)
-    end
-  end
-  vim.api.nvim_create_autocmd('BufLeave', {
-    callback = close,
-    once = true,
-    nested = true,
-    buffer = bufnr,
-  })
-  vim.api.nvim_create_autocmd('WinLeave', {
-    callback = close,
-    once = true,
-    nested = true,
-  })
 end
 
 return M


### PR DESCRIPTION
## Problem

`g?` opened a custom floating window with a flat list of keybindings — a bespoke UI that duplicated vimdoc and was inconsistent with Vim conventions (fugitive's `g?` opens `:help fugitive-maps`).

## Solution

Added a `*canola-keymaps*` section to `doc/canola.txt` documenting all default bindings. Changed `show_help` to run `:help canola-keymaps`. Removed `keymap_util.show_help` and its floating window code (~90 lines deleted).