### PR TITLE
feat(keymaps): bind gy to yank_entry by default

### DIFF
--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -22,6 +22,7 @@ local default_keymaps = {
   ['gs'] = { callback = 'actions.change_sort', mode = 'n' },
   ['gx'] = 'actions.open_external',
   ['g.'] = { callback = 'actions.toggle_hidden', mode = 'n' },
+  ['gy'] = { callback = 'actions.yank_entry', mode = 'n' },
   ['q'] = { callback = 'actions.close', mode = 'n' },
 }
 


### PR DESCRIPTION
## Problem

The `yank_entry` action existed but had no default keybinding. Copying a file's absolute path to a register required a custom keymap.

## Solution

Bind `gy` to `actions.yank_entry` in the default keymaps. Supports `vim.v.register` so `"agy` yanks to register `a`.