### PR TITLE
fix(session): clear buftype on VimLeavePre so mksession saves canola URLs

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -1717,6 +1717,19 @@ M.init = function()
       end
     end,
   })
+  vim.api.nvim_create_autocmd('VimLeavePre', {
+    desc = 'Clear buftype on canola buffers so mksession saves their URLs',
+    group = aug,
+    pattern = '*',
+    callback = function()
+      local util = require('canola.util')
+      for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_valid(bufnr) and util.is_canola_bufnr(bufnr) then
+          vim.bo[bufnr].buftype = ''
+        end
+      end
+    end,
+  })
 
   if config.float.default then
     vim.api.nvim_create_autocmd('VimEnter', {


### PR DESCRIPTION
## Problem

`mksession` treats `buftype='acwrite'` buffers as blank windows when `blank` is excluded from `sessionoptions`, causing canola windows to be silently omitted from saved sessions.

## Solution

Clear `buftype` on all canola buffers in `VimLeavePre` so the session writer sees them as regular file buffers and saves their `canola://` URLs. On restore, `BufReadCmd` re-initializes them normally. Mid-session `:mksession` calls are not yet covered — blocked by neovim/neovim#22814.

Canola-branch counterpart of #195. Closes #149.