### PR TITLE
build: separate ci devshell to avoid overriding system neovim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,19 @@
         default = pkgs.mkShell {
           packages = [
             pkgs.prettier
+            pkgs.stylua
+            pkgs.selene
+            vimdoc-language-server.packages.${pkgs.system}.default
+            (pkgs.luajit.withPackages (ps: [
+              ps.busted
+              ps.nlua
+            ]))
+          ];
+        };
+
+        ci = pkgs.mkShell {
+          packages = [
+            pkgs.prettier
             pkgs.neovim
             pkgs.stylua
             pkgs.selene

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -eu
 
-nix develop --command stylua --check lua spec
-git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
-nix develop --command prettier --check .
+nix develop .#ci --command stylua --check lua spec
+git ls-files '*.lua' | xargs nix develop .#ci --command selene --display-style quiet
+nix develop .#ci --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
-nix develop --command vimdoc-language-server check doc/
-nix develop --command busted
+nix develop .#ci --command vimdoc-language-server check doc/
+nix develop .#ci --command busted


### PR DESCRIPTION
## Problem

The default devshell included `pkgs.neovim` which overrode the user's system neovim (e.g. nightly) on PATH when entering the shell interactively.

## Solution

Move `pkgs.neovim` to a dedicated `ci` devshell. The default shell no longer includes neovim. `scripts/ci.sh` uses `nix develop .#ci` for all commands.