### PR TITLE
build: add neovim and vimdoc-language-server to devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1773840656,
+        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773971251,
-        "narHash": "sha256-1w/uY96peWmnfdggu4t+Xr5DL1IK69MOGN75C4VHQzA=",
+        "lastModified": 1774124539,
+        "narHash": "sha256-jNizGjgbM4gT3X7ljmiqv2fWPuLqfPLyJnKRGDhql6Y=",
         "owner": "barrettruth",
         "repo": "vimdoc-language-server",
-        "rev": "51da455e37404d7defbf79cdf4289250080b0278",
+        "rev": "dd273fdeabcfff07b266fded6533bc2856759164",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,20 +27,8 @@
             pkgs.prettier
             pkgs.stylua
             pkgs.selene
-            vimdoc-language-server.packages.${pkgs.system}.default
-            (pkgs.luajit.withPackages (ps: [
-              ps.busted
-              ps.nlua
-            ]))
-          ];
-        };
-
-        ci = pkgs.mkShell {
-          packages = [
-            pkgs.prettier
             pkgs.neovim
-            pkgs.stylua
-            pkgs.selene
+            pkgs.lua-language-server
             vimdoc-language-server.packages.${pkgs.system}.default
             (pkgs.luajit.withPackages (ps: [
               ps.busted


### PR DESCRIPTION
## Problem

Vimdoc CI failed with 14 unresolved tag warnings — devShell lacked neovim runtime help files.

## Solution

Add `vimdoc-language-server` flake input, `neovim` and `lua-language-server` to the default devShell.