### PR TITLE
fix(delete): allow deleting empty directories when recursive is false

### DIFF
--- a/lua/canola/adapters/files.lua
+++ b/lua/canola/adapters/files.lua
@@ -661,7 +661,7 @@ M.perform_action = function(action, cb)
     path = fs.posix_to_os_path(path)
 
     if action.entry_type == 'directory' and not config.delete.recursive then
-      cb('Recursive delete disabled (set delete.recursive = true to enable)')
+      uv.fs_rmdir(path, cb)
       return
     end
     fs.recursive_delete(action.entry_type, path, cb)

--- a/spec/files_spec.lua
+++ b/spec/files_spec.lua
@@ -75,7 +75,7 @@ describe('files adapter', function()
     config.delete.recursive = false
   end)
 
-  it('Refuses to delete directories when recursive is false', function()
+  it('Deletes empty directories when recursive is false', function()
     tmpdir:create({ 'a/' })
     local url = 'canola://' .. vim.fn.fnamemodify(tmpdir.path, ':p') .. 'a'
     local err = test_util.await(files.perform_action, 2, {
@@ -83,8 +83,20 @@ describe('files adapter', function()
       entry_type = 'directory',
       type = 'delete',
     })
+    assert.is_nil(err)
+    tmpdir:assert_fs({})
+  end)
+
+  it('Refuses to delete non-empty directories when recursive is false', function()
+    tmpdir:create({ 'a/', 'a/b.txt' })
+    local url = 'canola://' .. vim.fn.fnamemodify(tmpdir.path, ':p') .. 'a'
+    local err = test_util.await(files.perform_action, 2, {
+      url = url,
+      entry_type = 'directory',
+      type = 'delete',
+    })
     assert.is_not_nil(err)
-    tmpdir:assert_fs({ ['a/'] = true })
+    tmpdir:assert_fs({ ['a/'] = true, ['a/b.txt'] = 'a/b.txt' })
   end)
 
   it('Moves files', function()


### PR DESCRIPTION
## Problem

`delete.recursive = false` unconditionally blocked all directory deletion, including empty directories that only need a single `rmdir` call.

## Solution

Call `uv.fs_rmdir` directly when `recursive` is false. It succeeds for empty dirs and returns `ENOTEMPTY` for non-empty ones.