### PR TITLE
fix(view): skip rerender on modified buffers to preserve unsaved edits

### DIFF
--- a/lua/canola/mutator/init.lua
+++ b/lua/canola/mutator/init.lua
@@ -677,19 +677,18 @@ M.try_write_changes = function(confirm, cb)
         view.unlock_buffers()
         if err then
           err = string.format('[canola] Error applying actions: %s', err)
-          view.rerender_all_oil_buffers(nil, function()
+          view.rerender_all_oil_buffers({ force = true }, function()
             cb(err)
           end)
         else
           local current_entry = canola.get_cursor_entry()
           if current_entry then
-            -- get the entry under the cursor and make sure the cursor stays on it
             view.set_last_cursor(
               vim.api.nvim_buf_get_name(0),
               vim.split(current_entry.parsed_name or current_entry.name, '/')[1]
             )
           end
-          view.rerender_all_oil_buffers(nil, function(render_err)
+          view.rerender_all_oil_buffers({ force = true }, function(render_err)
             vim.api.nvim_exec_autocmds(
               'User',
               { pattern = 'CanolaMutationComplete', modeline = false, data = { actions = actions } }

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -231,8 +231,9 @@ M.rerender_all_oil_buffers = function(opts, callback)
   for _, bufnr in ipairs(buffers) do
     if hidden_buffers[bufnr] then
       vim.b[bufnr].oil_dirty = opts
-      -- We also need to mark this as nomodified so it doesn't interfere with quitting vim
       vim.bo[bufnr].modified = false
+      vim.schedule(cb)
+    elseif not opts.force and vim.bo[bufnr].modified then
       vim.schedule(cb)
     else
       M.render_buffer_async(bufnr, opts, cb)


### PR DESCRIPTION
## Problem

`rerender_all_oil_buffers` unconditionally re-renders visible buffers from cache, discarding in-progress edits. External callers like `canola-git` trigger this via async `BufEnter` callbacks (fired by `open_preview()` window switches), causing operations like `dj` to silently revert when preview is open.

## Solution

Skip visible modified buffers in `rerender_all_oil_buffers` unless `opts.force` is set. The mutator passes `force = true` since it must re-render after applying mutations.