### PR TITLE
feat(mutator): compact move/copy display in confirmation dialog

### DIFF
--- a/lua/canola/mutator/confirmation.lua
+++ b/lua/canola/mutator/confirmation.lua
@@ -4,6 +4,34 @@ local layout = require('canola.layout')
 local util = require('canola.util')
 local M = {}
 
+---@param line string
+---@return string
+local function compact_move_line(line)
+  local prefix, src, dest = line:match('^(%s+%u+%s+)(.+) -> (.+)$')
+  if not prefix then
+    return line
+  end
+  local last_sep = 0
+  for i = 1, math.min(#src, #dest) do
+    if src:sub(i, i) ~= dest:sub(i, i) then
+      break
+    end
+    if src:sub(i, i) == '/' then
+      last_sep = i
+    end
+  end
+  if last_sep == 0 then
+    return line
+  end
+  return string.format(
+    '%s%s{%s -> %s}',
+    prefix,
+    src:sub(1, last_sep),
+    src:sub(last_sep + 1),
+    dest:sub(last_sep + 1)
+  )
+end
+
 ---@param actions canola.Action[]
 ---@return boolean
 local function is_simple_edit(actions)
@@ -98,6 +126,9 @@ M.show = vim.schedule_wrap(function(actions, should_confirm, cb)
     end
     -- We can't handle lines with newlines in them
     line = line:gsub('\n', '')
+    if action.type == 'move' or action.type == 'copy' then
+      line = compact_move_line(line)
+    end
     table.insert(lines, line)
     local line_width = vim.api.nvim_strwidth(line)
     if line_width > max_line_width then


### PR DESCRIPTION
## Problem

Move/copy actions in the confirmation dialog repeat the full path twice, making it hard to spot what changed in deep directory trees.

## Solution

Collapse shared directory prefix into brace-diff format: `MOVE a/b/{foo -> bar}` instead of `MOVE a/b/foo -> a/b/bar`. Falls back to the original format when paths share no common directory.

Based on: stevearc/oil.nvim#741