### PR TITLE
fix(mutator): escape dash in compact move pattern

### DIFF
--- a/lua/canola/mutator/confirmation.lua
+++ b/lua/canola/mutator/confirmation.lua
@@ -7,7 +7,7 @@ local M = {}
 ---@param line string
 ---@return string
 local function compact_move_line(line)
-  local prefix, src, dest = line:match('^(%s+%u+%s+)(.+) -> (.+)$')
+  local prefix, src, dest = line:match('^(%s+%u+%s+)(.+) %-> (.+)$')
   if not prefix then
     return line
   end


### PR DESCRIPTION
## Problem

Lua patterns treat `-` as a lazy quantifier. The pattern ` -> ` was parsed as "0+ lazy spaces, `>`, space", causing `compact_move_line` to include ` -` in the source suffix.

## Solution

Escape the dash as `%->` so it matches a literal `-`.