### PR TITLE
feat(api): add `confirm` option to select function

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -840,6 +840,9 @@ select({opts}, {callback})                                            *canola.se
           {tab}        `nil|boolean` Open the buffer in a new tab
           {close}      `nil|boolean` Close the original canola buffer once
                        selection is made
+          {confirm}    `boolean`     If current buffer needs saving, pass this
+                       value directly into `canola.save` to determine whether to
+                       show confirmation prompt
           {handle_buffer_callback} `nil|fun(buf_id: integer)` If defined, all
                        other buffer related options here would be ignored. This
                        callback allows you to take over the process of opening

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -822,6 +822,8 @@ end
 ---@field horizontal? boolean Open the buffer in a horizontal split
 ---@field split? "aboveleft"|"belowright"|"topleft"|"botright" Split modifier
 ---@field tab? boolean Open the buffer in a new tab
+---@field confirm? boolean If current buffer needs saving, pass this value
+---directly into `canola.save` to determine whether to show confirmation prompt
 ---@field close? boolean Close the original oil buffer once selection is made
 ---@field handle_buffer_callback? fun(buf_id: integer) If defined, all other buffer related options here would be ignored. This callback allows you to take over the process of opening the buffer yourself.
 
@@ -904,7 +906,7 @@ M.select = function(opts, callback)
   end
   if any_moved and config.save ~= false then
     if config.save == 'auto' then
-      M.save()
+      M.save({ confirm = opts.confirm })
       return finish()
     end
     local ok, choice = pcall(vim.fn.confirm, 'Save changes?', 'Yes\nNo', 1)
@@ -913,7 +915,7 @@ M.select = function(opts, callback)
     elseif choice == 0 then
       return
     elseif choice == 1 then
-      M.save()
+      M.save({ confirm = opts.confirm })
       return finish()
     end
   end


### PR DESCRIPTION
This is a patch I've been using over Oil for awhile, while allows me to do:
```
    ["<C-l>"] = {
      callback = "actions.select",
      opts = {
        confirm = false,
      },
    },
```