### PR TITLE
fix: update bug report template for canola namespace

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -49,12 +49,6 @@ body:
 
   - type: textarea
     attributes:
-      label: 'Health check'
-      description: 'Output of `:checkhealth oil`'
-      render: text
-
-  - type: textarea
-    attributes:
       label: Minimal reproduction
       description: |
         Save the script below as `repro.lua`, edit if needed, and run:
@@ -70,8 +64,8 @@ body:
           spec = {
             {
               'barrettruth/canola.nvim',
-              config = function()
-                require('oil').setup({})
+              init = function()
+                vim.g.canola = {}
               end,
             },
           },


### PR DESCRIPTION
## Problem

The bug report template references a nonexistent `:checkhealth oil` health module and uses the old `require('oil').setup({})` API.

## Solution

Remove the health check field and update the minimal reproduction snippet to use `vim.g.canola = {}`.