### PR TITLE
fix(config): guard register_adapter against uninitialized config

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -145,6 +145,9 @@ end
 ---@param name string Adapter module name (resolved via require("canola.adapters." .. name))
 M.register_adapter = function(scheme, name)
   local config = require('canola.config')
+  if not config.adapters then
+    config.init()
+  end
   if config.adapters[scheme] then
     return
   end


### PR DESCRIPTION
## Problem

`register_adapter()` crashes with "attempt to index field 'adapters' (a nil value)" when canola-collection's plugin file loads before canola's own `plugin/canola.lua` calls `config.init()`.

Reported in #273.

## Solution

Check for nil `config.adapters` at the top of `register_adapter()` and call `config.init()` early if needed. `config.init()` is idempotent so double-calling is safe.

Closes #273