### PR TITLE
fix: remove nonexistent healthcheck from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -49,12 +49,6 @@ body:
 
   - type: textarea
     attributes:
-      label: 'Health check'
-      description: 'Output of `:checkhealth oil`'
-      render: text
-
-  - type: textarea
-    attributes:
       label: Minimal reproduction
       description: |
         Save the script below as `repro.lua`, edit if needed, and run:


### PR DESCRIPTION
## Problem

The bug report template asks for output of `:checkhealth oil`, but no health module exists. Users can't fill the field.

## Solution

Remove the health check field from the bug report template.

Closes #273 (partially — template was misleading the reporter).