### PR TITLE
feat(api): add `confirm` option to `select()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ All adapters have been moved to
 
 canola.nvim is built on [oil.nvim](https://github.com/stevearc/oil.nvim) by
 [stevearc](https://github.com/stevearc).
+
+Thanks to [llakala](https://github.com/llakala) for the `confirm` option on
+`select()` (#274).

--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -838,6 +838,9 @@ select({opts}, {callback})                                            *canola.se
           {split}      `nil|"aboveleft"|"belowright"|"topleft"|"botright"` Split
                        modifier
           {tab}        `nil|boolean` Open the buffer in a new tab
+          {confirm}    `nil|boolean` If true, always show mutation confirmation;
+                       if false, save silently with no prompts; if nil, respect
+                       config
           {close}      `nil|boolean` Close the original canola buffer once
                        selection is made
           {handle_buffer_callback} `nil|fun(buf_id: integer)` If defined, all

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -825,6 +825,7 @@ end
 ---@field horizontal? boolean Open the buffer in a horizontal split
 ---@field split? "aboveleft"|"belowright"|"topleft"|"botright" Split modifier
 ---@field tab? boolean Open the buffer in a new tab
+---@field confirm? boolean If true, always show confirmation; if false, never show; if nil, respect config
 ---@field close? boolean Close the original oil buffer once selection is made
 ---@field handle_buffer_callback? fun(buf_id: integer) If defined, all other buffer related options here would be ignored. This callback allows you to take over the process of opening the buffer yourself.
 
@@ -906,8 +907,8 @@ M.select = function(opts, callback)
     end
   end
   if any_moved and config.save ~= false then
-    if config.save == 'auto' then
-      M.save()
+    if config.save == 'auto' or opts.confirm == false then
+      M.save({ confirm = opts.confirm })
       return finish()
     end
     local ok, choice = pcall(vim.fn.confirm, 'Save changes?', 'Yes\nNo', 1)
@@ -916,7 +917,7 @@ M.select = function(opts, callback)
     elseif choice == 0 then
       return
     elseif choice == 1 then
-      M.save()
+      M.save({ confirm = opts.confirm })
       return finish()
     end
   end


### PR DESCRIPTION
## Problem

There is no way to skip the save/confirmation prompts on a per-keymap basis. Users who want instant navigation must set `config.save = 'auto'` globally.

## Solution

Add `opts.confirm` to `select()`. When `false`, both the outer "Save changes?" dialog and the inner mutation confirmation are bypassed. When `true`, confirmation is always shown. When `nil`, the existing config is respected.

Based on #274 by @llakala.