### PR TITLE
feat(actions): add `add_to_qflist` action

### DIFF
--- a/lua/canola/actions.lua
+++ b/lua/canola/actions.lua
@@ -417,6 +417,22 @@ M.change_sort = {
   },
 }
 
+M.add_to_qflist = {
+  desc = 'Add the entry under the cursor (or visual selection) to the quickfix list.',
+  callback = function(opts)
+    opts = opts or {}
+    util.add_to_quickfix({
+      target = opts.target,
+    })
+  end,
+  parameters = {
+    target = {
+      type = '"qflist"|"loclist"',
+      desc = 'The target list to add entries to',
+    },
+  },
+}
+
 M.send_to_qflist = {
   desc = 'Sends files in the current oil directory to the quickfix list, replacing the previous entries.',
   callback = function(opts)

--- a/lua/canola/util.lua
+++ b/lua/canola/util.lua
@@ -813,6 +813,56 @@ M.send_to_quickfix = function(opts)
   vim.api.nvim_exec_autocmds('QuickFixCmdPost', {})
 end
 
+M.add_to_quickfix = function(opts)
+  if type(opts) ~= 'table' then
+    opts = {}
+  end
+  local canola = require('canola')
+  local dir = canola.get_current_dir()
+  if type(dir) ~= 'string' then
+    return
+  end
+  local range = M.get_visual_range()
+  local qf_entries = {}
+  if range then
+    for i = range.start_lnum, range.end_lnum do
+      local entry = canola.get_entry_on_line(0, i)
+      if entry and entry.type == 'file' then
+        table.insert(qf_entries, {
+          filename = dir .. entry.name,
+          lnum = 1,
+          col = 1,
+        })
+      end
+    end
+  else
+    local entry = canola.get_cursor_entry()
+    if entry and entry.type == 'file' then
+      table.insert(qf_entries, {
+        filename = dir .. entry.name,
+        lnum = 1,
+        col = 1,
+      })
+    end
+  end
+  if #qf_entries == 0 then
+    vim.notify('[canola] No file entries to add to quickfix', vim.log.levels.WARN)
+    return
+  end
+  vim.api.nvim_exec_autocmds('QuickFixCmdPre', {})
+  if opts.target == 'loclist' then
+    vim.fn.setloclist(0, {}, 'a', { title = 'canola files', items = qf_entries })
+  else
+    vim.fn.setqflist({}, 'a', { title = 'canola files', items = qf_entries })
+  end
+  vim.api.nvim_exec_autocmds('QuickFixCmdPost', {})
+  local count = #qf_entries
+  local names = vim.tbl_map(function(e)
+    return e.text
+  end, qf_entries)
+  vim.notify(('[canola] Added %s to quickfix'):format(table.concat(names, ', ')))
+end
+
 ---@return boolean
 M.is_visual_mode = function()
   local mode = vim.api.nvim_get_mode().mode


### PR DESCRIPTION
## Problem

`send_to_qflist` sends every file in the directory to the quickfix list. There is no way to add individual files or a visual selection without a custom action. Requested in #281, where a user provided a working custom implementation.

## Solution

Add `add_to_qflist` action that appends the cursor entry (or visual selection) to the quickfix list. Supports `target` parameter for loclist. Does not auto-open the quickfix window — the user runs `:copen` when ready.

Closes #281