### PR TITLE
feat(float): add `title` option to disable floating window title

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -201,6 +201,8 @@ The full list of options with their defaults:
       },
       -- Configuration for the floating window in oil.open_float
       float = {
+        -- Set to false to disable the floating window title
+        title = true,
         -- Padding around the floating window
         padding = 2,
         -- max_width and max_height can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)

--- a/lua/oil/config.lua
+++ b/lua/oil/config.lua
@@ -134,6 +134,7 @@ local default_config = {
   },
   -- Configuration for the floating window in oil.open_float
   float = {
+    title = true,
     -- Padding around the floating window
     padding = 2,
     -- max_width and max_height can be integers or a float between 0 and 1 (e.g. 0.4 for 40%)
@@ -411,6 +412,7 @@ local M = {}
 ---@field minimized_border? string|string[] The border for the minimized progress window
 
 ---@class (exact) oil.FloatWindowConfig
+---@field title boolean
 ---@field padding integer
 ---@field max_width integer
 ---@field max_height integer
@@ -421,6 +423,7 @@ local M = {}
 ---@field override fun(conf: table): table
 
 ---@class (exact) oil.SetupFloatWindowConfig
+---@field title? boolean
 ---@field padding? integer
 ---@field max_width? integer
 ---@field max_height? integer

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -326,18 +326,20 @@ M.open_float = function(dir, opts, cb)
           vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
         end
 
-        if config.float.border ~= nil and config.float.border ~= 'none' then
-          local cur_win_opts = vim.api.nvim_win_get_config(winid)
-          vim.api.nvim_win_set_config(winid, {
-            relative = 'editor',
-            row = cur_win_opts.row,
-            col = cur_win_opts.col,
-            width = cur_win_opts.width,
-            height = cur_win_opts.height,
-            title = util.get_title(winid),
-          })
-        else
-          util.add_title_to_win(winid)
+        if config.float.title then
+          if config.float.border ~= nil and config.float.border ~= 'none' then
+            local cur_win_opts = vim.api.nvim_win_get_config(winid)
+            vim.api.nvim_win_set_config(winid, {
+              relative = 'editor',
+              row = cur_win_opts.row,
+              col = cur_win_opts.col,
+              width = cur_win_opts.width,
+              height = cur_win_opts.height,
+              title = util.get_title(winid),
+            })
+          else
+            util.add_title_to_win(winid)
+          end
         end
       end,
     })
@@ -357,7 +359,7 @@ M.open_float = function(dir, opts, cb)
     end
   end)
 
-  if config.float.border == nil or config.float.border == 'none' then
+  if config.float.title and (config.float.border == nil or config.float.border == 'none') then
     util.add_title_to_win(winid)
   end
 end


### PR DESCRIPTION
## Problem

The floating window title is always shown and cannot be disabled, causing visual overlap on some configurations.

## Solution

Add `float.title` boolean config option (default `true`) that gates both the native border title and the separate title window. Set `float.title = false` to disable.

Closes #285