### PR TITLE
feat(float): add `title` option to disable floating window title

### DIFF
--- a/doc/canola.nvim.txt
+++ b/doc/canola.nvim.txt
@@ -410,6 +410,7 @@ The full list of options with their defaults:
 
       float = {
         default = false,
+        title = true,
         padding = 2,
         max_width = 0,
         max_height = 0,

--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -50,6 +50,7 @@ local default_config = {
 
   float = {
     default = false,
+    title = true,
     padding = 2,
     max_width = 0,
     max_height = 0,
@@ -165,6 +166,7 @@ local M = {}
 
 ---@class (exact) canola.FloatConfig
 ---@field default boolean
+---@field title boolean
 ---@field padding integer
 ---@field max_width integer
 ---@field max_height integer

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -391,18 +391,20 @@ M.open_float = function(dir, opts, cb)
           vim.api.nvim_set_option_value(k, v, { scope = 'local', win = winid })
         end
 
-        if config.float.border ~= nil and config.float.border ~= 'none' then
-          local cur_win_opts = vim.api.nvim_win_get_config(winid)
-          vim.api.nvim_win_set_config(winid, {
-            relative = 'editor',
-            row = cur_win_opts.row,
-            col = cur_win_opts.col,
-            width = cur_win_opts.width,
-            height = cur_win_opts.height,
-            title = util.get_title(winid),
-          })
-        else
-          util.add_title_to_win(winid)
+        if config.float.title then
+          if config.float.border ~= nil and config.float.border ~= 'none' then
+            local cur_win_opts = vim.api.nvim_win_get_config(winid)
+            vim.api.nvim_win_set_config(winid, {
+              relative = 'editor',
+              row = cur_win_opts.row,
+              col = cur_win_opts.col,
+              width = cur_win_opts.width,
+              height = cur_win_opts.height,
+              title = util.get_title(winid),
+            })
+          else
+            util.add_title_to_win(winid)
+          end
         end
       end,
     })
@@ -422,7 +424,7 @@ M.open_float = function(dir, opts, cb)
     end
   end)
 
-  if config.float.border == nil or config.float.border == 'none' then
+  if config.float.title and (config.float.border == nil or config.float.border == 'none') then
     util.add_title_to_win(winid)
   end
 end


### PR DESCRIPTION
## Problem

The floating window title is always shown and cannot be disabled, causing visual overlap on some configurations.

## Solution

Add `float.title` boolean option to `vim.g.canola` (default `true`) that gates both the native border title and the separate title window. Set `float.title = false` to disable.

Canola-branch counterpart of the main-branch PR. Closes #285