### PR TITLE
docs: add `*canola.nvim*` and `*canola.nvim.txt*` tags

### DIFF
--- a/doc/canola.nvim.txt
+++ b/doc/canola.nvim.txt
@@ -1,6 +1,6 @@
-*canola.txt*
+*canola.nvim.txt*
 
-*canola* *Canola*
+*canola* *canola.nvim* *Canola*
 ------------------------------------------------------------------------------
 CONTENTS                                                     *canola-contents*
 


### PR DESCRIPTION
## Problem

Help file tags only had `*canola.txt*` and `*canola*` — no `*canola.nvim*` or `*canola.nvim.txt*` tag, so `:h canola.nvim` didn't resolve.

## Solution

Add `*canola.nvim.txt*` and `*canola.nvim*` tags.