### PR TITLE
feat(view): eza-like symlink target highlighting

### DIFF
--- a/lua/canola/adapters/files.lua
+++ b/lua/canola/adapters/files.lua
@@ -113,7 +113,7 @@ if not fs.is_windows then
 
     render = function(entry, conf)
       local meta = entry[FIELD_META]
-      local stat = meta and meta.stat
+      local stat = meta and (meta.lstat or meta.stat)
       if not stat then
         return columns.EMPTY
       end
@@ -136,7 +136,7 @@ if not fs.is_windows then
 
     render = function(entry, conf)
       local meta = entry[FIELD_META]
-      local stat = meta and meta.stat
+      local stat = meta and (meta.lstat or meta.stat)
       if not stat then
         return columns.EMPTY
       end
@@ -404,6 +404,13 @@ local function fetch_entry_metadata(parent_dir, entry, require_stat, cb)
         -- Use the fstat of the linked file as the stat for the link
         meta.link_stat = link_stat
         meta.stat = link_stat
+        uv.fs_lstat(entry_path, function(lstat_err, lstat)
+          if not lstat_err and lstat then
+            meta.lstat = lstat
+          end
+          cb()
+        end)
+        return
       elseif require_stat then
         -- The link is broken, so let's use the stat of the link itself
         uv.fs_lstat(entry_path, function(stat_err, stat)
@@ -412,6 +419,7 @@ local function fetch_entry_metadata(parent_dir, entry, require_stat, cb)
             return cb()
           end
           meta.stat = stat
+          meta.lstat = stat
           cb()
         end)
         return

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -1128,7 +1128,8 @@ M._get_highlights = function()
     {
       name = 'CanolaOrphanLink',
       link = 'DiagnosticError',
-      desc = 'Orphaned soft links in an oil buffer',
+      bold = true,
+      desc = 'Arrow separator for orphaned soft links',
     },
     {
       name = 'CanolaLinkHidden',
@@ -1148,6 +1149,7 @@ M._get_highlights = function()
     {
       name = 'CanolaOrphanLinkTarget',
       link = 'DiagnosticError',
+      bold = true,
       underline = true,
       desc = 'The target of an orphaned soft link',
     },
@@ -1163,7 +1165,8 @@ M._get_highlights = function()
     },
     {
       name = 'CanolaLinkArrow',
-      link = 'Comment',
+      terminal_color = 8,
+      bold = true,
       desc = 'The arrow separator (-> ) between a soft link and its target',
     },
     {

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -1114,7 +1114,7 @@ M.format_entry_line = function(entry, adapter, is_hidden, bufnr)
       if highlight_as_executable then
         link_name_hl = 'CanolaExecutable' .. hl_suffix
       else
-        link_name_hl = (is_orphan and 'CanolaOrphanLink' or 'CanolaLink') .. hl_suffix
+        link_name_hl = 'CanolaLink' .. hl_suffix
       end
     end
     table.insert(cols, { link_name, link_name_hl })
@@ -1150,7 +1150,7 @@ M.format_entry_line = function(entry, adapter, is_hidden, bufnr)
           elseif highlight_as_executable then
             base_hl = 'CanolaExecutable' .. hl_suffix
           else
-            local target_type = meta.link_stat.type
+            local target_type = meta.link_stat and meta.link_stat.type
             if target_type == 'directory' then
               base_hl = 'CanolaDir' .. hl_suffix
             elseif target_type == 'socket' then


### PR DESCRIPTION
## Summary

Split symlink target display into three separately highlighted segments,
matching eza's symlink rendering model:

| Segment | Example (`nvim` link) | Highlight |
|---|---|---|
| symlink name | `nvim/` | `CanolaLink` (bold cyan) |
| arrow | `->` | `CanolaLinkArrow` (Comment) |
| directory prefix | `/home/.../config/` | `CanolaLinkPath` (inherits CanolaLink) |
| target basename | `nvim/` | resolved type: `CanolaDir`, `CanolaFile`, `CanolaExecutable`, `CanolaSocket` |

Orphan (broken) symlinks highlight all target segments with
`CanolaOrphanLinkTarget` (`DiagnosticError` = red).

### New highlight groups

- `CanolaLinkArrow` / `CanolaLinkArrowHidden`
- `CanolaLinkPath` / `CanolaLinkPathHidden`

### Implementation

Uses existing sub-highlight support in `compute_highlights_for_cols` to
apply multiple highlight groups within a single text chunk, avoiding
extra spaces from `render_table`'s column join.

Resolves #278