### PR TITLE
fix(mutator): wipe deleted buffers shown behind floats

### DIFF
--- a/lua/canola/mutator/init.lua
+++ b/lua/canola/mutator/init.lua
@@ -13,6 +13,19 @@ local util = require('canola.util')
 local view = require('canola.view')
 local M = {}
 
+local function wipe_buffer(bufnr)
+  local wins = vim.fn.win_findbuf(bufnr)
+  for _, winid in ipairs(wins) do
+    if vim.api.nvim_win_is_valid(winid) then
+      vim.api.nvim_win_call(winid, function()
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+      return
+    end
+  end
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end
+
 M.create_actions_from_diffs = function(all_diffs)
   return action_creation.create_actions_from_diffs(all_diffs)
 end
@@ -69,7 +82,7 @@ M.process_actions = function(actions, cb)
               local os_path = fs.posix_to_os_path(path)
               local bufnr = vim.fn.bufnr(os_path)
               if bufnr ~= -1 then
-                vim.api.nvim_buf_delete(bufnr, { force = true })
+                wipe_buffer(bufnr)
               end
             end
           end

--- a/lua/canola/mutator/init.lua
+++ b/lua/canola/mutator/init.lua
@@ -13,19 +13,6 @@ local util = require('canola.util')
 local view = require('canola.view')
 local M = {}
 
-local function wipe_buffer(bufnr)
-  local wins = vim.fn.win_findbuf(bufnr)
-  for _, winid in ipairs(wins) do
-    if vim.api.nvim_win_is_valid(winid) then
-      vim.api.nvim_win_call(winid, function()
-        vim.api.nvim_buf_delete(bufnr, { force = true })
-      end)
-      return
-    end
-  end
-  vim.api.nvim_buf_delete(bufnr, { force = true })
-end
-
 M.create_actions_from_diffs = function(all_diffs)
   return action_creation.create_actions_from_diffs(all_diffs)
 end
@@ -82,7 +69,19 @@ M.process_actions = function(actions, cb)
               local os_path = fs.posix_to_os_path(path)
               local bufnr = vim.fn.bufnr(os_path)
               if bufnr ~= -1 then
-                wipe_buffer(bufnr)
+                local did_delete = false
+                for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+                  if vim.api.nvim_win_is_valid(winid) then
+                    vim.api.nvim_win_call(winid, function()
+                      vim.api.nvim_buf_delete(bufnr, { force = true })
+                    end)
+                    did_delete = true
+                    break
+                  end
+                end
+                if not did_delete then
+                  vim.api.nvim_buf_delete(bufnr, { force = true })
+                end
               end
             end
           end

--- a/spec/files_spec.lua
+++ b/spec/files_spec.lua
@@ -218,6 +218,25 @@ describe('files adapter', function()
       assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
     end)
 
+    it('wipes the buffer for a deleted file behind a float', function()
+      local canola = require('canola')
+      tmpdir:create({ 'c.txt' })
+      local dirurl = 'canola://' .. vim.fn.fnamemodify(tmpdir.path, ':p')
+      local filepath = vim.fn.fnamemodify(tmpdir.path, ':p') .. 'c.txt'
+      cache.create_and_store_entry(dirurl, 'c.txt', 'file')
+      vim.cmd.edit({ args = { filepath } })
+      local bufnr = vim.api.nvim_get_current_buf()
+      test_util.await(canola.open_float, 3, tmpdir.path)
+      local original_win = vim.w.canola_original_win
+      assert(vim.api.nvim_win_is_valid(original_win))
+      assert.equals(bufnr, vim.api.nvim_win_get_buf(original_win))
+      local url = 'canola://' .. filepath
+      test_util.await(mutator.process_actions, 2, {
+        { type = 'delete', url = url, entry_type = 'file' },
+      })
+      assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+    end)
+
     it('does not wipe the buffer when disabled', function()
       config.delete.wipe = false
       tmpdir:create({ 'b.txt' })


### PR DESCRIPTION
Why: `delete.wipe` did not wipe file buffers that were still displayed in the window behind a Canola float, so deleting the current file from a float left the background buffer alive. Fixes #304.

How: The mutator cleanup path now finds a window that is actually displaying the target buffer and runs `nvim_buf_delete()` from there when needed. A regression spec covers the float background-buffer case.