### PR TITLE
feat(columns): reserve width for fully empty opt-in columns

### DIFF
--- a/doc/canola.nvim.txt
+++ b/doc/canola.nvim.txt
@@ -687,6 +687,11 @@ register_column({name}, {column})                     *canola.register_column*
               Alternative to `get_sort_value` for implementations that need
               to precompute state across all entries. Takes precedence when
               present.
+          {all_empty_width} `nil|integer|fun(conf, bufnr): integer|nil`
+              Reserve this width when the column is fully empty for the
+              current listing. The reserved area renders as blank space.
+              Columns without this hook still collapse when all visible
+              entries return `columns.EMPTY`.
           {compare} `nil|fun(entry, parsed_value): boolean`
               Returns true when the parsed value differs from the entry's
               current state. Only needed for columns representing mutable

--- a/lua/canola/columns.lua
+++ b/lua/canola/columns.lua
@@ -20,6 +20,7 @@ local all_columns = {}
 ---@field get_sort_value? fun(entry: canola.InternalEntry): number|string
 ---@field create_sort_value_factory? fun(num_entries: integer): fun(entry: canola.InternalEntry): number|string
 ---@field default_align? canola.ColumnAlign
+---@field all_empty_width? integer|fun(conf: nil|table, bufnr: integer): integer|nil
 
 ---@param name string
 ---@param column canola.ColumnDefinition
@@ -89,6 +90,25 @@ M.render_col = function(adapter, col_def, entry, bufnr)
     end
   end
   return chunk
+end
+
+---@param adapter canola.Adapter
+---@param col_def canola.ColumnSpec
+---@param bufnr integer
+---@return integer?
+M.get_all_empty_width = function(adapter, col_def, bufnr)
+  local name, conf = util.split_config(col_def)
+  local column = M.get_column(adapter, name)
+  if not column then
+    return
+  end
+  local width = column.all_empty_width
+  if type(width) == 'function' then
+    width = width(conf, bufnr)
+  end
+  if type(width) == 'number' and width > 0 then
+    return width
+  end
 end
 
 ---@param adapter canola.Adapter

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -129,6 +129,7 @@ end
 ---@field fs_event? any uv_fs_event_t
 ---@field col_width? integer[]
 ---@field col_align? canola.ColumnAlign[]
+---@field col_blank? boolean[]
 ---@field hl_cache? table<integer, { line: string, name_highlights: table[], virt_chunks: table[] }>
 
 -- List of bufnrs
@@ -159,10 +160,22 @@ local col_ns = vim.api.nvim_create_namespace('CanolaColumns')
 ---@type table<integer, {adapter: canola.Adapter, column_defs: canola.ColumnSpec[]}>
 local decor_ctx = {}
 
-local function render_col_virt_chunks(adapter, column_defs, col_width, col_align, entry, bufnr)
+local function render_col_virt_chunks(
+  adapter,
+  column_defs,
+  col_width,
+  col_align,
+  col_blank,
+  entry,
+  bufnr
+)
   local virt_chunks = {}
   for i, col_def in ipairs(column_defs) do
     if (col_width[i] or 0) > 0 then
+      if col_blank[i] then
+        table.insert(virt_chunks, { string.rep(' ', col_width[i]) .. ' ' })
+        goto continue
+      end
       local chunk = columns.render_col(adapter, col_def, entry, bufnr)
       local text = type(chunk) == 'table' and chunk[1] or chunk
       ---@cast text string
@@ -181,6 +194,7 @@ local function render_col_virt_chunks(adapter, column_defs, col_width, col_align
         table.insert(virt_chunks, { padded .. ' ', hl })
       end
     end
+    ::continue::
   end
   return virt_chunks
 end
@@ -605,9 +619,11 @@ local function render_buffer(bufnr, opts)
   local line_table = {}
   local col_width = {}
   local col_align = {}
+  local col_blank = {}
   local col_has_data = {}
   for i, col_def in ipairs(column_defs) do
     col_width[i] = 1
+    col_blank[i] = false
     col_has_data[i] = false
     local name, conf = util.split_config(col_def)
     local col = columns.get_column(adapter, col_def)
@@ -650,7 +666,14 @@ local function render_buffer(bufnr, opts)
   local col_pad = 0
   for i = 1, #col_width do
     if not col_has_data[i] then
-      col_width[i] = 0
+      local width = columns.get_all_empty_width(adapter, column_defs[i], bufnr)
+      if width then
+        col_width[i] = width
+        col_blank[i] = true
+        col_pad = col_pad + col_width[i] + 1
+      else
+        col_width[i] = 0
+      end
     else
       col_pad = col_pad + col_width[i] + 1
     end
@@ -683,8 +706,15 @@ local function render_buffer(bufnr, opts)
     if id then
       local entry = id == 0 and parent_entry or cache.get_entry_by_id(id)
       if entry then
-        local virt_chunks =
-          render_col_virt_chunks(adapter, column_defs, col_width, col_align, entry, bufnr)
+        local virt_chunks = render_col_virt_chunks(
+          adapter,
+          column_defs,
+          col_width,
+          col_align,
+          col_blank,
+          entry,
+          bufnr
+        )
         if #virt_chunks > 0 then
           local id_prefix = line:match('^/%d+ ')
           if id_prefix then
@@ -702,6 +732,7 @@ local function render_buffer(bufnr, opts)
   _rendering[bufnr] = nil
   session[bufnr].col_width = col_width
   session[bufnr].col_align = col_align
+  session[bufnr].col_blank = col_blank
   session[bufnr].hl_cache = nil
 
   if opts.jump then
@@ -959,8 +990,9 @@ M.setup_decoration_provider = function()
         if entry and sess then
           local cw = sess.col_width or {}
           local ca = sess.col_align or {}
+          local cb = sess.col_blank or {}
           local cd = ctx.column_defs
-          local virt_chunks = render_col_virt_chunks(ctx.adapter, cd, cw, ca, entry, bufnr)
+          local virt_chunks = render_col_virt_chunks(ctx.adapter, cd, cw, ca, cb, entry, bufnr)
           if #virt_chunks > 0 then
             local id_prefix = line:match('^/%d+ ')
             if id_prefix then

--- a/spec/regression_spec.lua
+++ b/spec/regression_spec.lua
@@ -276,4 +276,57 @@ describe('regression tests', function()
       assert.are.same({ ' ', 'CanolaFileIcon' }, columns.render_col(adapter, 'icon', file, 0))
     end)
   end)
+
+  it('keeps fully empty custom columns collapsed by default', function()
+    local test_adapter = require('canola.adapters.test')
+    canola.register_column('blank', {
+      render = function()
+        return require('canola.columns').EMPTY
+      end,
+    })
+    vim.g.canola = {
+      cursor = true,
+      columns = { 'blank' },
+      adapters = {
+        ['canola-test://'] = 'test',
+      },
+      save = false,
+    }
+    canola.init()
+    test_adapter.test_set('/foo/a.txt', 'file')
+    test_adapter.test_set('/foo/b.txt', 'file')
+    vim.cmd.edit({ args = { 'canola-test:///foo/' } })
+    test_util.wait_for_autocmd({ 'User', pattern = 'CanolaEnter' })
+    assert.equals(0, view.get_col_pad(0))
+  end)
+
+  it('can reserve width for fully empty custom columns', function()
+    local test_adapter = require('canola.adapters.test')
+    canola.register_column('blank_reserved', {
+      render = function()
+        return require('canola.columns').EMPTY
+      end,
+      all_empty_width = 1,
+    })
+    vim.g.canola = {
+      cursor = true,
+      columns = { 'blank_reserved' },
+      adapters = {
+        ['canola-test://'] = 'test',
+      },
+      save = false,
+    }
+    canola.init()
+    test_adapter.test_set('/foo/a.txt', 'file')
+    test_adapter.test_set('/foo/b.txt', 'file')
+    vim.cmd.edit({ args = { 'canola-test:///foo/' } })
+    test_util.wait_for_autocmd({ 'User', pattern = 'CanolaEnter' })
+    assert.equals(2, view.get_col_pad(0))
+    local ns = vim.api.nvim_get_namespaces().CanolaColumns
+    local extmarks = vim.api.nvim_buf_get_extmarks(0, ns, 0, -1, { details = true })
+    assert.is_true(#extmarks > 0)
+    for _, extmark in ipairs(extmarks) do
+      assert.equals('  ', extmark[4].virt_text[1][1])
+    end
+  end)
 end)


### PR DESCRIPTION
This adds an opt-in all_empty_width hook to canola column definitions so status-like columns can keep a stable layout even when every visible entry is empty. The default behavior is unchanged: fully empty columns still collapse unless they explicitly opt in.

The renderer now reserves width for opted-in fully empty columns and draws that reserved area as blank space, so there is no need for placeholder glyphs or Unicode hacks. The change is covered with regression tests for both the default collapsing path and the new opt-in behavior, and local just ci passes in the worktree.