### PR TITLE
fix(view): normalize windows watch paths

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -29,7 +29,7 @@ issues against this fork.
 | [#708](https://github.com/stevearc/oil.nvim/pull/708) | Move file into new dir by renaming                                     | consolidated into [#32](https://github.com/barrettruth/canola.nvim/issues/32)                                                     |
 | [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents                                | not actionable — `OilFileCreated` event already covers the use case (see [#280](https://github.com/stevearc/oil.nvim/issues/280)) |
 | [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split                                | deferred — tracked as [#2](https://github.com/barrettruth/canola.nvim/issues/2)                                                   |
-| [#744](https://github.com/stevearc/oil.nvim/pull/744) | fix: use os path when watching for changes                             | open                                                                                                                              |
+| [#744](https://github.com/stevearc/oil.nvim/pull/744) | fix: use os path when watching for changes                             | fixed ([#320](https://github.com/barrettruth/canola.nvim/pull/320))                                                               |
 | [#748](https://github.com/stevearc/oil.nvim/pull/748) | fix: add bounds check in calc_constrained_cursor_pos to prevent index… | open                                                                                                                              |
 
 ## Issues

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -738,36 +738,39 @@ M.initialize = function(bufnr)
     local fs_event = assert(uv.new_fs_event())
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     local _, dir = util.parse_url(bufname)
-    fs_event:start(
-      assert(dir),
-      {},
-      vim.schedule_wrap(function(err, filename, events)
-        if not vim.api.nvim_buf_is_valid(bufnr) then
-          local sess = session[bufnr]
-          if sess then
-            sess.fs_event = nil
-          end
-          fs_event:stop()
-          return
-        end
-        local mutator = require('oil.mutator')
-        if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
-          return
-        end
-
-        -- If the buffer is currently visible, rerender
-        for _, winid in ipairs(vim.api.nvim_list_wins()) do
-          if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
-            M.render_buffer_async(bufnr)
+    if not (fs.is_windows and dir == '/') then
+      local os_path = fs.posix_to_os_path(assert(dir))
+      fs_event:start(
+        os_path,
+        {},
+        vim.schedule_wrap(function(err, filename, events)
+          if not vim.api.nvim_buf_is_valid(bufnr) then
+            local sess = session[bufnr]
+            if sess then
+              sess.fs_event = nil
+            end
+            fs_event:stop()
             return
           end
-        end
+          local mutator = require('oil.mutator')
+          if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
+            return
+          end
 
-        -- If it is not currently visible, mark it as dirty
-        vim.b[bufnr].oil_dirty = {}
-      end)
-    )
-    session[bufnr].fs_event = fs_event
+          -- If the buffer is currently visible, rerender
+          for _, winid in ipairs(vim.api.nvim_list_wins()) do
+            if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
+              M.render_buffer_async(bufnr)
+              return
+            end
+          end
+
+          -- If it is not currently visible, mark it as dirty
+          vim.b[bufnr].oil_dirty = {}
+        end)
+      )
+      session[bufnr].fs_event = fs_event
+    end
   end
 
   -- Watch for TextChanged and update the trash original path extmarks

--- a/spec/watch_spec.lua
+++ b/spec/watch_spec.lua
@@ -1,0 +1,61 @@
+local config = require('oil.config')
+local fs = require('oil.fs')
+local test_util = require('spec.test_util')
+local view = require('oil.view')
+
+describe('watcher paths', function()
+  local uv = vim.uv or vim.loop
+  local old_is_windows
+  local old_new_fs_event
+  local old_render_buffer_async
+  local old_watch_for_changes
+  local started_path
+  local start_calls
+
+  before_each(function()
+    started_path = nil
+    start_calls = 0
+    old_is_windows = fs.is_windows
+    old_new_fs_event = uv.new_fs_event
+    old_render_buffer_async = view.render_buffer_async
+    old_watch_for_changes = config.watch_for_changes
+    fs.is_windows = true
+    config.watch_for_changes = true
+    uv.new_fs_event = function()
+      return {
+        start = function(_, path)
+          start_calls = start_calls + 1
+          started_path = path
+        end,
+        stop = function() end,
+      }
+    end
+    view.render_buffer_async = function() end
+  end)
+
+  after_each(function()
+    fs.is_windows = old_is_windows
+    config.watch_for_changes = old_watch_for_changes
+    uv.new_fs_event = old_new_fs_event
+    view.render_buffer_async = old_render_buffer_async
+    test_util.reset_editor()
+  end)
+
+  it('uses an os path when starting file watchers on windows', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_buf_set_name(bufnr, 'oil:///C/tmp/oil-test/')
+    view.initialize(bufnr)
+    assert.equals('C:\\tmp\\oil-test\\', started_path)
+    assert.equals(1, start_calls)
+  end)
+
+  it('skips starting a watcher for the windows drive list buffer', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_buf_set_name(bufnr, 'oil:///')
+    view.initialize(bufnr)
+    assert.is_nil(started_path)
+    assert.equals(0, start_calls)
+  end)
+end)


### PR DESCRIPTION
## Problem

`watch_for_changes` passes parsed oil buffer URLs directly to `uv.fs_event_start`, so Windows watcher setup receives a URL path instead of an OS path. The synthetic Windows drive-list buffer can also try to watch `/`, which is not a real directory.

## Solution

Convert the parsed directory through `fs.posix_to_os_path()` before starting the watcher and skip watcher setup for the synthetic Windows drive-list buffer. Add focused regression specs covering both the normalized watch path and the drive-list guard.