### PR TITLE
fix(view): normalize windows watch paths

### DIFF
--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -5,6 +5,7 @@ local config = require('canola.config')
 local constants = require('canola.constants')
 local cursor = require('canola.cursor')
 local entry_format = require('canola.entry_format')
+local fs = require('canola.fs')
 local insert = require('canola.insert')
 local keymap_util = require('canola.keymap_util')
 local loading = require('canola.loading')
@@ -468,36 +469,39 @@ M.initialize = function(bufnr)
     local fs_event = assert(uv.new_fs_event())
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     local _, dir = util.parse_url(bufname)
-    fs_event:start(
-      assert(dir),
-      {},
-      vim.schedule_wrap(function(err, filename, events)
-        if not vim.api.nvim_buf_is_valid(bufnr) then
-          local sess = session[bufnr]
-          if sess then
-            sess.fs_event = nil
-          end
-          fs_event:stop()
-          return
-        end
-        local mutator = require('canola.mutator')
-        if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
-          return
-        end
-
-        -- If the buffer is currently visible, rerender
-        for _, winid in ipairs(vim.api.nvim_list_wins()) do
-          if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
-            M.render_buffer_async(bufnr)
+    if not (fs.is_windows and dir == '/') then
+      local os_path = fs.posix_to_os_path(assert(dir))
+      fs_event:start(
+        os_path,
+        {},
+        vim.schedule_wrap(function(err, filename, events)
+          if not vim.api.nvim_buf_is_valid(bufnr) then
+            local sess = session[bufnr]
+            if sess then
+              sess.fs_event = nil
+            end
+            fs_event:stop()
             return
           end
-        end
+          local mutator = require('canola.mutator')
+          if err or vim.bo[bufnr].modified or vim.b[bufnr].oil_dirty or mutator.is_mutating() then
+            return
+          end
 
-        -- If it is not currently visible, mark it as dirty
-        vim.b[bufnr].oil_dirty = {}
-      end)
-    )
-    session[bufnr].fs_event = fs_event
+          -- If the buffer is currently visible, rerender
+          for _, winid in ipairs(vim.api.nvim_list_wins()) do
+            if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr then
+              M.render_buffer_async(bufnr)
+              return
+            end
+          end
+
+          -- If it is not currently visible, mark it as dirty
+          vim.b[bufnr].oil_dirty = {}
+        end)
+      )
+      session[bufnr].fs_event = fs_event
+    end
   end
 
   M.render_buffer_async(bufnr, {}, function(err)

--- a/spec/watch_spec.lua
+++ b/spec/watch_spec.lua
@@ -1,0 +1,61 @@
+local config = require('canola.config')
+local fs = require('canola.fs')
+local test_util = require('spec.test_util')
+local view = require('canola.view')
+
+describe('watcher paths', function()
+  local uv = vim.uv
+  local old_is_windows
+  local old_new_fs_event
+  local old_render_buffer_async
+  local old_watch
+  local started_path
+  local start_calls
+
+  before_each(function()
+    started_path = nil
+    start_calls = 0
+    old_is_windows = fs.is_windows
+    old_new_fs_event = uv.new_fs_event
+    old_render_buffer_async = view.render_buffer_async
+    old_watch = config.watch
+    fs.is_windows = true
+    config.watch = true
+    uv.new_fs_event = function()
+      return {
+        start = function(_, path)
+          start_calls = start_calls + 1
+          started_path = path
+        end,
+        stop = function() end,
+      }
+    end
+    view.render_buffer_async = function() end
+  end)
+
+  after_each(function()
+    fs.is_windows = old_is_windows
+    config.watch = old_watch
+    uv.new_fs_event = old_new_fs_event
+    view.render_buffer_async = old_render_buffer_async
+    test_util.reset_editor()
+  end)
+
+  it('uses an os path when starting file watchers on windows', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_buf_set_name(bufnr, 'canola:///C/tmp/canola-test/')
+    view.initialize(bufnr)
+    assert.equals('C:\\tmp\\canola-test\\', started_path)
+    assert.equals(1, start_calls)
+  end)
+
+  it('skips starting a watcher for the windows drive list buffer', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_buf_set_name(bufnr, 'canola:///')
+    view.initialize(bufnr)
+    assert.is_nil(started_path)
+    assert.equals(0, start_calls)
+  end)
+end)


### PR DESCRIPTION
## Problem

`config.watch` passes parsed canola buffer URLs directly to `uv.fs_event_start`, so Windows watcher setup receives a URL path instead of an OS path. The synthetic Windows drive-list buffer can also try to watch `/`, which is not a real directory.

## Solution

Convert the parsed directory through `fs.posix_to_os_path()` before starting the watcher and skip watcher setup for the synthetic Windows drive-list buffer. Add focused regression specs covering both the normalized watch path and the drive-list guard.