### PR TITLE
fix(view): guard stale constrained cursor rows

### DIFF
--- a/doc/upstream.md
+++ b/doc/upstream.md
@@ -30,7 +30,7 @@ issues against this fork.
 | [#721](https://github.com/stevearc/oil.nvim/pull/721) | `create_hook` to populate file contents                                | not actionable — `OilFileCreated` event already covers the use case (see [#280](https://github.com/stevearc/oil.nvim/issues/280)) |
 | [#728](https://github.com/stevearc/oil.nvim/pull/728) | `open_split` for opening oil in a split                                | deferred — tracked as [#2](https://github.com/barrettruth/canola.nvim/issues/2)                                                   |
 | [#744](https://github.com/stevearc/oil.nvim/pull/744) | fix: use os path when watching for changes                             | fixed ([#320](https://github.com/barrettruth/canola.nvim/pull/320))                                                               |
-| [#748](https://github.com/stevearc/oil.nvim/pull/748) | fix: add bounds check in calc_constrained_cursor_pos to prevent index… | open                                                                                                                              |
+| [#748](https://github.com/stevearc/oil.nvim/pull/748) | fix: add bounds check in calc_constrained_cursor_pos to prevent index… | fixed ([#322](https://github.com/barrettruth/canola.nvim/pull/322))                                                               |
 
 ## Issues
 

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -290,6 +290,10 @@ end
 --- @return integer[] | nil
 local function calc_constrained_cursor_pos(bufnr, adapter, mode, cur)
   local parser = require('oil.mutator.parser')
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if cur[1] < 1 or cur[1] > line_count then
+    return
+  end
   local line = vim.api.nvim_buf_get_lines(bufnr, cur[1] - 1, cur[1], true)[1]
   local column_defs = columns.get_supported_columns(adapter)
   local result = parser.parse_line(adapter, line, column_defs)

--- a/spec/cursor_spec.lua
+++ b/spec/cursor_spec.lua
@@ -1,0 +1,40 @@
+local test_util = require('spec.test_util')
+local util = require('oil.util')
+local view = require('oil.view')
+
+local function get_upvalue(fn, target)
+  for i = 1, 20 do
+    local name, value = debug.getupvalue(fn, i)
+    if name == target then
+      return value
+    end
+  end
+end
+
+local function demo_lines()
+  local lines = {}
+  for i = 1, 40 do
+    lines[i] = string.format('/%d file_%02d', i, i)
+  end
+  return lines
+end
+
+describe('cursor constraints', function()
+  after_each(function()
+    test_util.reset_editor()
+  end)
+
+  it('does not error when a stale cursor row is beyond the loading buffer', function()
+    local constrain_cursor = assert(get_upvalue(view.initialize, 'constrain_cursor'))
+    local calc = assert(get_upvalue(constrain_cursor, 'calc_constrained_cursor_pos'))
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.bo[bufnr].buftype = 'nofile'
+    vim.bo[bufnr].bufhidden = 'wipe'
+    vim.bo[bufnr].swapfile = false
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, demo_lines())
+    local stale = { 40, 0 }
+    util.render_text(bufnr, { 'Loading', '[===]' }, { h_align = 'left', v_align = 'top' })
+    assert.is_nil(calc(bufnr, nil, 'editable', stale))
+  end)
+end)


### PR DESCRIPTION
## Problem

Async rerenders can temporarily shrink an oil buffer to a loading or partial-render state while the cursor still points at a stale row. `calc_constrained_cursor_pos()` then reads that row with strict indexing and errors with `Index out of bounds`.

## Solution

Check the current line count before reading the cursor row and return `nil` when the row is outside the buffer, letting Neovim clamp the cursor after the rerender. Add a focused regression spec that reproduces the stale-cursor loading-buffer case.