### PR TITLE
fix(cursor): guard stale constrained cursor rows

### DIFF
--- a/lua/canola/cursor.lua
+++ b/lua/canola/cursor.lua
@@ -47,6 +47,10 @@ end
 --- @param col_pad integer
 --- @return integer[]|nil
 M.calc_constrained_cursor_pos = function(bufnr, adapter, mode, cur, col_pad)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  if cur[1] < 1 or cur[1] > line_count then
+    return
+  end
   local line = vim.api.nvim_buf_get_lines(bufnr, cur[1] - 1, cur[1], true)[1]
   local id_prefix = line:match('^/%d+ ')
   if id_prefix then

--- a/spec/cursor_spec.lua
+++ b/spec/cursor_spec.lua
@@ -1,0 +1,29 @@
+local cursor = require('canola.cursor')
+local test_util = require('spec.test_util')
+local util = require('canola.util')
+
+local function demo_lines()
+  local lines = {}
+  for i = 1, 40 do
+    lines[i] = string.format('/%d file_%02d', i, i)
+  end
+  return lines
+end
+
+describe('cursor constraints', function()
+  after_each(function()
+    test_util.reset_editor()
+  end)
+
+  it('does not error when a stale cursor row is beyond the loading buffer', function()
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.bo[bufnr].buftype = 'nofile'
+    vim.bo[bufnr].bufhidden = 'wipe'
+    vim.bo[bufnr].swapfile = false
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, demo_lines())
+    local stale = { 40, 0 }
+    util.render_text(bufnr, { 'Loading', '[===]' }, { h_align = 'left', v_align = 'top' })
+    assert.is_nil(cursor.calc_constrained_cursor_pos(bufnr, nil, 'editable', stale, 0))
+  end)
+end)


### PR DESCRIPTION
## Problem

Async rerenders can temporarily shrink a canola buffer to a loading or partial-render state while the cursor still points at a stale row. `calc_constrained_cursor_pos()` then reads that row with strict indexing and errors with `Index out of bounds`.

## Solution

Check the current line count before reading the cursor row and return `nil` when the row is outside the buffer, letting Neovim clamp the cursor after the rerender. Add a focused regression spec that reproduces the stale-cursor loading-buffer case.