### PR TITLE
fix(migrate): preserve non-default oil settings

### DIFF
--- a/lua/oil/migrate.lua
+++ b/lua/oil/migrate.lua
@@ -19,9 +19,35 @@ local sort_presets = {
   ['size,desc|name,asc'] = 'size',
 }
 
+local default_sort = {
+  { 'type', 'asc' },
+  { 'name', 'asc' },
+}
+
+local canola_default_keys = {
+  ['g?'] = true,
+  ['<CR>'] = true,
+  ['<C-s>'] = true,
+  ['<C-h>'] = true,
+  ['<C-t>'] = true,
+  ['<C-p>'] = true,
+  ['<C-c>'] = true,
+  ['<C-l>'] = true,
+  ['-'] = true,
+  ['_'] = true,
+  ['`'] = true,
+  ['g~'] = true,
+  ['gs'] = true,
+  ['gx'] = true,
+  ['g.'] = true,
+  ['gy'] = true,
+  ['q'] = true,
+}
+
+local default_simple_border = vim.fn.has('nvim-0.11') == 0 and 'rounded' or nil
+
 local removed_defaults = {
   default_file_explorer = true,
-  use_default_keymaps = true,
   cleanup_delay_ms = 2000,
   extra_scp_args = {},
   extra_s3_args = {},
@@ -174,12 +200,17 @@ local function is_default_git(git)
   return a and m and r
 end
 
+local function add_manual(manual, option, reason)
+  table.insert(manual, string.format('`%s`: %s', option, reason))
+end
+
 M.generate = function()
   local cfg = require('oil.config')
   local out = {}
   local hooks = {}
   local removed = {}
   local adapters = {}
+  local manual = {}
 
   out.columns = cfg.columns
 
@@ -188,13 +219,28 @@ M.generate = function()
   elseif cfg.constrain_cursor == false then
     out.cursor = false
   end
+  if cfg.constrain_cursor == 'name' then
+    add_manual(
+      manual,
+      'constrain_cursor = "name"',
+      'canola only supports `cursor = true|false`; `true` behaves like oil `"editable"`'
+    )
+  end
 
   out.watch = cfg.watch_for_changes or false
 
-  if not is_default_table(cfg.view_options.sort, { { 'type', 'asc' }, { 'name', 'asc' } }) then
+  if
+    not is_default_table(cfg.view_options.sort, default_sort)
+    or cfg.view_options.natural_order ~= 'fast'
+    or cfg.view_options.case_insensitive ~= false
+  then
     local key = sort_key(cfg.view_options.sort)
     local preset = sort_presets[key]
-    if preset then
+    if
+      preset
+      and cfg.view_options.natural_order == 'fast'
+      and cfg.view_options.case_insensitive == false
+    then
       out.sort = preset
     else
       out.sort = {
@@ -212,11 +258,23 @@ M.generate = function()
     hidden.enabled = true
   end
   out.hidden = hidden
+  if cfg.view_options.show_hidden_when_empty then
+    add_manual(manual, 'view_options.show_hidden_when_empty', 'removed in canola')
+  end
 
-  if cfg.skip_confirm_for_simple_edits and cfg.skip_confirm_for_delete then
-    out.confirm = false
-  elseif cfg.skip_confirm_for_simple_edits then
-    out.confirm = 'delete'
+  if cfg.skip_confirm_for_simple_edits or cfg.skip_confirm_for_delete then
+    local parts = {}
+    if cfg.skip_confirm_for_simple_edits then
+      table.insert(parts, 'skip_confirm_for_simple_edits')
+    end
+    if cfg.skip_confirm_for_delete then
+      table.insert(parts, 'skip_confirm_for_delete')
+    end
+    add_manual(
+      manual,
+      table.concat(parts, ' / '),
+      'canola `confirm` cannot exactly reproduce oil confirmation rules; review this manually'
+    )
   end
 
   if cfg.auto_save_on_select_new_entry then
@@ -271,14 +329,23 @@ M.generate = function()
     ['g\\'] = true,
   }
   local custom_keymaps = {}
-  for k, v in pairs(keymaps) do
-    if not default_keys[k] then
+  if not cfg.use_default_keymaps then
+    for k in pairs(canola_default_keys) do
+      custom_keymaps[k] = false
+    end
+    for k, v in pairs(keymaps) do
       custom_keymaps[k] = v
     end
-  end
-  for k, v in pairs(keymaps) do
-    if default_keys[k] and v == false then
-      custom_keymaps[k] = false
+  else
+    for k, v in pairs(keymaps) do
+      if not default_keys[k] then
+        custom_keymaps[k] = v
+      end
+    end
+    for k, v in pairs(keymaps) do
+      if default_keys[k] and v == false then
+        custom_keymaps[k] = false
+      end
     end
   end
   if next(custom_keymaps) then
@@ -288,6 +355,9 @@ M.generate = function()
   local float = {}
   if cfg.default_to_float then
     float.default = true
+  end
+  if cfg.float.title == false then
+    float.title = false
   end
   if cfg.float.padding ~= 2 then
     float.padding = cfg.float.padding
@@ -317,6 +387,12 @@ M.generate = function()
   end
   if cfg.preview_win.preview_method == 'load' then
     preview.live = true
+  elseif cfg.preview_win.preview_method == 'scratch' then
+    add_manual(
+      manual,
+      'preview_win.preview_method = "scratch"',
+      'canola has no scratch preview mode; `preview.live = false` uses fast_scratch'
+    )
   end
   if cfg.preview_win.max_file_size ~= 10 then
     preview.max_file_size_mb = cfg.preview_win.max_file_size
@@ -395,6 +471,14 @@ M.generate = function()
   end
   if next(progress) then
     out.progress = progress
+  end
+
+  if not is_default_table(cfg.ssh, { border = default_simple_border }) then
+    add_manual(manual, 'ssh.border', 'no core canola equivalent; SSH UI lives in canola-collection')
+  end
+
+  if not is_default_table(cfg.keymaps_help, { border = default_simple_border }) then
+    add_manual(manual, 'keymaps_help.border', 'removed in canola; help now uses vimdoc')
   end
 
   if type(cfg.float.override) == 'function' and not is_default_override(cfg.float.override) then
@@ -559,7 +643,7 @@ end)
     end
   end
 
-  return out, hooks, removed, adapters
+  return out, hooks, removed, adapters, manual
 end
 
 local function add(md, s)
@@ -576,7 +660,7 @@ local function block(md, lines)
 end
 
 M.print = function()
-  local out, hooks, removed, adapters = M.generate()
+  local out, hooks, removed, adapters, manual = M.generate()
   local md = {}
   local hook_map = {}
   for _, h in ipairs(hooks) do
@@ -718,6 +802,17 @@ M.print = function()
     end
   end
 
+  if #manual > 0 then
+    add(md, '')
+    add(md, '## Manual Review')
+    add(md, '')
+    add(md, 'These oil.nvim settings do not have an exact canola equivalent:')
+    add(md, '')
+    for _, item in ipairs(manual) do
+      add(md, '- ' .. item)
+    end
+  end
+
   if #removed > 0 then
     add(md, '')
     add(md, '## Removed Options')
@@ -741,6 +836,10 @@ M.print = function()
   if next(hook_map) then
     step = step + 1
     add(md, step .. '. Add the autocmd replacements from Hook Replacements')
+  end
+  if #manual > 0 then
+    step = step + 1
+    add(md, step .. '. Review the Manual Review section and adjust any lossy settings')
   end
   step = step + 1
   add(md, step .. '. See `:h canola-recipes` for new features (git, brace expansion, etc.)')

--- a/spec/migrate_spec.lua
+++ b/spec/migrate_spec.lua
@@ -6,6 +6,10 @@ local function current_buffer_text()
   return table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, true), '\n')
 end
 
+local function joined(lines)
+  return table.concat(lines, '\n')
+end
+
 describe('migrate', function()
   before_each(function()
     test_util.reset_editor()
@@ -16,9 +20,13 @@ describe('migrate', function()
     test_util.reset_editor()
   end)
 
+  local function generate(opts)
+    config.setup(opts)
+    return migrate.generate()
+  end
+
   it('moves delete_to_trash to canola-collection config', function()
-    config.setup({ delete_to_trash = true })
-    local out, _, _, adapters = migrate.generate()
+    local out, _, _, adapters = generate({ delete_to_trash = true })
     assert.is_nil(out.delete)
     assert.is_true(
       vim.tbl_contains(
@@ -26,6 +34,74 @@ describe('migrate', function()
         'delete_to_trash -> vim.g.canola_trash = {} (requires canola-collection)'
       )
     )
+  end)
+
+  it('migrates sort flags even when the sort preset itself stays the same', function()
+    local out = generate({
+      view_options = {
+        natural_order = true,
+        case_insensitive = true,
+      },
+    })
+    assert.same({
+      by = {
+        { 'type', 'asc' },
+        { 'name', 'asc' },
+      },
+      natural = true,
+      ignore_case = true,
+    }, out.sort)
+  end)
+
+  it('migrates float.title when disabled', function()
+    local out = generate({
+      float = { title = false },
+    })
+    assert.same({ title = false }, out.float)
+  end)
+
+  it('disables canola default keymaps when oil defaults are disabled', function()
+    local out, _, removed = generate({
+      use_default_keymaps = false,
+      keymaps = {
+        ['<CR>'] = 'actions.select',
+        q = 'actions.close',
+      },
+    })
+    assert.same('actions.select', out.keymaps['<CR>'])
+    assert.same('actions.close', out.keymaps.q)
+    assert.is_false(out.keymaps['g?'])
+    assert.is_false(out.keymaps['<C-p>'])
+    assert.is_false(out.keymaps.gy)
+    assert.is_false(vim.tbl_contains(removed, 'use_default_keymaps'))
+  end)
+
+  it('reports lossy and removed settings instead of dropping them silently', function()
+    local out, _, _, _, manual = generate({
+      view_options = { show_hidden_when_empty = true },
+      constrain_cursor = 'name',
+      preview_win = { preview_method = 'scratch' },
+      ssh = { border = 'double' },
+      keymaps_help = { border = 'double' },
+    })
+    local text = joined(manual)
+    assert.is_true(out.cursor)
+    assert.matches('show_hidden_when_empty', text)
+    assert.matches('constrain_cursor = "name"', text)
+    assert.matches('preview_win%.preview_method = "scratch"', text)
+    assert.matches('ssh%.border', text)
+    assert.matches('keymaps_help%.border', text)
+  end)
+
+  it('does not widen oil confirmation behavior when there is no exact canola equivalent', function()
+    local out, _, _, _, manual = generate({
+      skip_confirm_for_simple_edits = true,
+      skip_confirm_for_delete = true,
+    })
+    local text = joined(manual)
+    assert.is_nil(out.confirm)
+    assert.matches('skip_confirm_for_simple_edits', text)
+    assert.matches('skip_confirm_for_delete', text)
   end)
 
   it('prints canola-git as an opt-in collection config', function()
@@ -52,5 +128,19 @@ describe('migrate', function()
     assert.matches('vim%.g%.canola_git = %{%}', text)
     assert.is_not_nil(text:match('git_status'))
     assert.is_nil(text:match('No config needed'))
+  end)
+
+  it('prints manual review items for lossy migrations', function()
+    config.setup({
+      skip_confirm_for_simple_edits = true,
+      constrain_cursor = 'name',
+      preview_win = { preview_method = 'scratch' },
+    })
+    migrate.print()
+    local text = current_buffer_text()
+    assert.matches('## Manual Review', text)
+    assert.matches('skip_confirm_for_simple_edits', text)
+    assert.matches('constrain_cursor = "name"', text)
+    assert.matches('preview_win%.preview_method = "scratch"', text)
   end)
 end)


### PR DESCRIPTION
Why: `:Oil --migrate` was silently dropping or broadening several non-default Oil settings, which made the generated `vim.g.canola` config drift from live behavior.

How: Teach `lua/oil/migrate.lua` to preserve representable sort, float, and keymap settings, and emit a `Manual Review` section for lossy translations instead of dropping them. Expand `spec/migrate_spec.lua` to lock down exact mappings and the printed migration output.