### PR TITLE
docs(pr): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## Problem
+
+## Solution


### PR DESCRIPTION
## Problem

Pull requests against `main` had no repository PR template, so CLI-created PRs fell back to the generic `Why` / `How` body instead of the repo's preferred `Problem` / `Solution` format.

## Solution

Add `.github/pull_request_template.md` on `main` with the same minimal `Problem` / `Solution` structure already used on `canola`.