### PR TITLE
docs(oil): restore missing defaults in vimdoc

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -90,11 +90,14 @@ The full list of options with their defaults:
       },
       -- Send deleted files to the trash instead of permanently deleting them (:help oil-trash)
       delete_to_trash = false,
+      cleanup_buffers_on_delete = false,
       -- Skip the confirmation popup for simple operations (:help oil.skip_confirm_for_simple_edits)
       skip_confirm_for_simple_edits = false,
+      skip_confirm_for_delete = false,
       -- Selecting a new/moved/renamed file or directory will prompt you to save changes first
       -- (:help prompt_save_on_select_new_entry)
       prompt_save_on_select_new_entry = true,
+      auto_save_on_select_new_entry = false,
       -- Oil will automatically delete hidden buffers after this delay
       -- You can set the delay to false to disable cleanup entirely
       -- Note that the cleanup process only starts when none of the oil buffers are currently displayed


### PR DESCRIPTION
## Problem

`doc/oil.txt` says it shows the full defaults block, but it omits three real top-level options from `lua/oil/config.lua`. Fixes #325.

## Solution

Add `cleanup_buffers_on_delete`, `skip_confirm_for_delete`, and `auto_save_on_select_new_entry` to the defaults example so the documented config block matches the actual `main` config surface.