### PR TITLE
feat(issues): split live issue forms by branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_canola.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_canola.yaml
@@ -1,16 +1,16 @@
-name: Bug Report (main / oil-compatible)
-description: Report a bug on the backwards-compatible oil track
-title: 'bug(main): '
+name: Bug Report (canola)
+description: Report a bug on the active canola track
+title: 'bug(canola): '
 labels: [bug]
 body:
   - type: markdown
     attributes:
       value: |
-        You are filing against the `main` branch.
+        You are filing against the `canola` branch.
 
-        - `main` is the backwards-compatible oil track.
-        - Use `require('oil').setup(...)`.
-        - If your repro uses `vim.g.canola` or `require('canola')`, use **Bug Report (canola)** instead.
+        - `canola` is the active refactor track.
+        - Use `vim.g.canola` before the plugin loads.
+        - If you need drop-in `require('oil').setup(...)` compatibility, use **Bug Report (main / oil-compatible)** instead.
 
   - type: checkboxes
     attributes:
@@ -20,13 +20,13 @@ body:
             I have searched [existing
             issues](https://github.com/barrettruth/canola.nvim/issues)
           required: true
-        - label: I have updated to the latest `main` branch
+        - label: I have updated to the latest `canola` branch
           required: true
         - label:
-            This report targets the `main` branch, the backwards-compatible
-            oil track
+            This report targets the `canola` branch, the active
+            non-backwards-compatible track
           required: true
-        - label: I ran the repro below with `branch = 'main'` left intact
+        - label: I ran the repro below with `branch = 'canola'` left intact
           required: true
 
   - type: textarea
@@ -71,8 +71,8 @@ body:
         ```
         nvim -u repro.lua
         ```
-        Do not remove or change `branch = 'main'`. That pin tells us this issue
-        is on the backwards-compatible track.
+        Do not remove or change `branch = 'canola'`. That pin tells us this
+        issue is on the active canola track.
       render: lua
       value: |
         vim.env.LAZY_STDPATH = '.repro'
@@ -81,9 +81,9 @@ body:
           spec = {
             {
               'barrettruth/canola.nvim',
-              branch = 'main',
-              config = function()
-                require('oil').setup({})
+              branch = 'canola',
+              init = function()
+                vim.g.canola = {}
               end,
             },
           },

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,8 +1,17 @@
-name: Feature Request
-description: Suggest a feature
-title: 'feat: '
+name: Feature Request (main / oil-compatible)
+description: Propose a backwards-compatible improvement for the stable oil track
+title: 'feat(main): '
 labels: [enhancement]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        You are filing against the `main` branch.
+
+        - `main` is the backwards-compatible oil track.
+        - Requests here must preserve `require('oil').setup(...)`, existing keymaps, and drop-in compatibility.
+        - If you want a canola-only API or config shape, use **Feature Request (canola)** instead.
+
   - type: checkboxes
     attributes:
       label: Prerequisites
@@ -11,6 +20,19 @@ body:
             I have searched [existing
             issues](https://github.com/barrettruth/canola.nvim/issues)
           required: true
+        - label: This request targets the `main` branch
+          required: true
+        - label:
+            This request preserves `require('oil').setup(...)` and backwards
+            compatibility
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Why should this land on `main`?
+      description: Explain why this belongs on the backwards-compatible oil track instead of `canola`.
+    validations:
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request_canola.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_canola.yaml
@@ -1,0 +1,45 @@
+name: Feature Request (canola)
+description: Propose a feature for the active canola track
+title: 'feat(canola): '
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You are filing against the `canola` branch.
+
+        - `canola` is the active refactor track.
+        - Use `vim.g.canola` for config.
+        - New canola-only APIs, config shapes, and behavior changes belong here.
+        - If this must preserve `require('oil').setup(...)` compatibility, use **Feature Request (main / oil-compatible)** instead.
+
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label:
+            I have searched [existing
+            issues](https://github.com/barrettruth/canola.nvim/issues)
+          required: true
+        - label: This request targets the `canola` branch
+          required: true
+        - label:
+            I understand `canola` is the active non-backwards-compatible track
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered


### PR DESCRIPTION
## Problem

GitHub only serves issue forms from the default branch, so the live issue chooser on `main` could not distinguish between the oil-compatible `main` track and the refactor `canola` track. The bug-report repro template also did not pin the plugin branch, so reporters could start from the wrong API and config shape.

## Solution

Make the default-branch issue forms branch-aware by turning the existing bug and feature forms into explicit `main` forms, adding `*_canola.yaml` variants, and pinning each repro snippet to the matching branch with required acknowledgements. I also validated the resulting issue-form YAML locally.