### PR TITLE
fix(migrate): keep canola docs reachable from main

### DIFF
--- a/doc/oil.txt
+++ b/doc/oil.txt
@@ -15,6 +15,7 @@ CONTENTS                                                            *oil-content
   10. Recipes                                                    |oil-recipes|
   11. Events                                                      |oil-events|
   12. Trash                                                        |oil-trash|
+  13. Canola migration                                    |canola-migration|
 
 --------------------------------------------------------------------------------
 INTRODUCTION                                                    *oil-introduction*
@@ -1516,6 +1517,33 @@ Mac:
 
 Windows:
     Oil supports the Windows Recycle Bin. All features should work.
+
+--------------------------------------------------------------------------------
+MIGRATING TO THE CANOLA BRANCH                            *canola-migration*
+
+The full `canola-migration` guide ships with the `canola` branch, not `main`.
+If you are reading this help file on `main`, switch your plugin manager entry
+to `branch = "canola"` and update the plugin before following the guide.
+
+You can run `:Oil --migrate` on `main` to generate a starting point from your
+current oil.nvim config. After switching branches, use these help topics:
+
+- `:h canola-migration`
+- `:h canola-migration-removed`
+- `:h canola-recipes`
+
+------------------------------------------------------------------------------
+REMOVED OPTIONS                                  *canola-migration-removed*
+
+This section is documented on the `canola` branch as part of
+`:h canola-migration`. Switch to `branch = "canola"` and reopen that topic
+there.
+
+------------------------------------------------------------------------------
+RECIPES                                                     *canola-recipes*
+
+This section is documented on the `canola` branch. Switch to
+`branch = "canola"` to view the current canola recipes.
 
 ================================================================================
 vim:tw=80:ts=2:ft=help:norl:syntax=help:

--- a/lua/oil/migrate.lua
+++ b/lua/oil/migrate.lua
@@ -823,14 +823,14 @@ M.print = function()
       add(md, '- `' .. key .. '`')
     end
     add(md, '')
-    add(md, 'See `:h canola-migration-removed` for details.')
+    add(md, 'See `:h canola-migration-removed` for canola-branch details.')
   end
 
   add(md, '')
   add(md, '## Next Steps')
   add(md, '')
   local step = 1
-  add(md, step .. '. Set `branch = "canola"` in your plugin manager')
+  add(md, step .. '. Switch your plugin manager entry to `branch = "canola"`')
   step = step + 1
   add(md, step .. '. Replace `require("oil").setup({...})` with the config above')
   if next(hook_map) then
@@ -842,9 +842,13 @@ M.print = function()
     add(md, step .. '. Review the Manual Review section and adjust any lossy settings')
   end
   step = step + 1
-  add(md, step .. '. See `:h canola-recipes` for new features (git, brace expansion, etc.)')
+  add(
+    md,
+    step
+      .. '. After switching branches, see `:h canola-recipes` for new features (git, brace expansion, etc.)'
+  )
   add(md, '')
-  add(md, 'Full reference: `:h canola-migration`')
+  add(md, 'Full canola-branch reference: `:h canola-migration`')
 
   local text = table.concat(md, '\n')
 


### PR DESCRIPTION
## Problem

On `main`, `:Oil --migrate` points users at `:h canola-migration` and related canola help tags, but those topics only ship with the `canola` branch. Users on `main` can hit blank help and the migration flow dead-ends.

## Solution

Add main-branch help stubs for `canola-migration`, `canola-migration-removed`, and `canola-recipes`, and update `:Oil --migrate` so it explicitly says the full guide lives on the `canola` branch after switching.