### PR TITLE
fix(float): respect resolved border for titles

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -327,8 +327,8 @@ M.open_float = function(dir, opts, cb)
         end
 
         if config.float.title then
-          if config.float.border ~= nil and config.float.border ~= 'none' then
-            local cur_win_opts = vim.api.nvim_win_get_config(winid)
+          local cur_win_opts = vim.api.nvim_win_get_config(winid)
+          if cur_win_opts.border ~= 'none' then
             vim.api.nvim_win_set_config(winid, {
               relative = 'editor',
               row = cur_win_opts.row,
@@ -359,7 +359,7 @@ M.open_float = function(dir, opts, cb)
     end
   end)
 
-  if config.float.title and (config.float.border == nil or config.float.border == 'none') then
+  if config.float.title and vim.api.nvim_win_get_config(winid).border == 'none' then
     util.add_title_to_win(winid)
   end
 end


### PR DESCRIPTION
## Problem

On `main`, floating oil windows decide between native border titles and the fallback overlay title window by looking only at `config.float.border`. When users leave that setting at `nil` but set Neovim's global `winborder`, oil opens a real bordered float and still creates the fallback overlay title window, so the title overlaps the directory listing.

## Solution

Route the title decision through the resolved runtime border from `nvim_win_get_config(winid)`. Floats that actually have a border now use the native window title, while truly borderless floats keep the fallback overlay title window.