### PR TITLE
fix(float): respect resolved border for titles

### DIFF
--- a/lua/canola/window.lua
+++ b/lua/canola/window.lua
@@ -96,8 +96,8 @@ M.open_float = function(dir, opts, cb)
         end
 
         if config.float.title then
-          if config.float.border ~= nil and config.float.border ~= 'none' then
-            local cur_win_opts = vim.api.nvim_win_get_config(winid)
+          local cur_win_opts = vim.api.nvim_win_get_config(winid)
+          if cur_win_opts.border ~= 'none' then
             vim.api.nvim_win_set_config(winid, {
               relative = 'editor',
               row = cur_win_opts.row,
@@ -128,7 +128,7 @@ M.open_float = function(dir, opts, cb)
     end
   end)
 
-  if config.float.title and (config.float.border == nil or config.float.border == 'none') then
+  if config.float.title and vim.api.nvim_win_get_config(winid).border == 'none' then
     util.add_title_to_win(winid)
   end
 end


### PR DESCRIPTION
## Problem

On `canola`, floating canola windows decide between native border titles and the fallback overlay title window by looking only at `config.float.border`. When users leave that setting at `nil` but set Neovim's global `winborder`, canola opens a real bordered float and still creates the fallback overlay title window, so the title overlaps the directory listing.

Closes #336.

## Solution

Route the title decision through the resolved runtime border from `nvim_win_get_config(winid)`. Floats that actually have a border now use the native window title, while truly borderless floats keep the fallback overlay title window.