### PR TITLE
fix(init): avoid async load context leaks

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -436,11 +436,7 @@ M.load_oil_buffer = function(bufnr)
     if not vim.api.nvim_buf_is_valid(bufnr) then
       return
     end
-    -- Since this was async, we may have left the window with this buffer. People often write
-    -- BufReadPre/Post autocmds with the expectation that the current window is the one that
-    -- contains the buffer. Let's then do our best to make sure that that assumption isn't violated.
-    winid = util.buf_get_win(bufnr, winid) or vim.api.nvim_get_current_win()
-    vim.api.nvim_win_call(winid, function()
+    local function finish_in_context()
       if new_url ~= bufname then
         if util.rename_buffer(bufnr, new_url) then
           -- If the buffer was replaced then don't initialize it. It's dead. The replacement will
@@ -469,7 +465,18 @@ M.load_oil_buffer = function(bufnr)
         adapter.read_file(bufnr)
       end
       restore_alt_buf()
-    end)
+    end
+
+    -- Since this was async, we may have left the window with this buffer. People often write
+    -- BufReadPre/Post autocmds with the expectation that the current window is the one that
+    -- contains the buffer. If the buffer is no longer visible, still make the target buffer
+    -- current for the finish path instead of falling back to an unrelated current window.
+    winid = util.buf_get_win(bufnr, winid)
+    if winid then
+      vim.api.nvim_win_call(winid, finish_in_context)
+    else
+      vim.api.nvim_buf_call(bufnr, finish_in_context)
+    end
   end
 
   adapter.normalize_url(bufname, finish)

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -345,7 +345,10 @@ M.initialize = function(bufnr)
   for k, v in pairs(config.buf) do
     vim.bo[bufnr][k] = v
   end
-  vim.api.nvim_buf_call(bufnr, M.set_win_options)
+  local visible_winid = util.buf_get_win(bufnr)
+  if visible_winid then
+    vim.api.nvim_win_call(visible_winid, M.set_win_options)
+  end
 
   vim.api.nvim_create_autocmd('BufUnload', {
     group = 'Canola',

--- a/spec/regression_spec.lua
+++ b/spec/regression_spec.lua
@@ -70,6 +70,45 @@ describe('regression tests', function()
     assert.equals('canola', vim.bo.filetype)
   end)
 
+  it("doesn't finish async directory loads in an unrelated current buffer", function()
+    local files = require('canola.adapters.files')
+    local old_normalize_url = files.normalize_url
+    local pending_finish
+
+    files.normalize_url = function(url, callback)
+      pending_finish = function()
+        callback(url)
+      end
+    end
+
+    local ok, err = xpcall(function()
+      tmpdir:create({ 'a.txt' })
+      vim.cmd.edit({ args = { 'canola://' .. vim.fn.fnamemodify(tmpdir.path, ':p') .. '/' } })
+      local canola_bufnr = vim.api.nvim_get_current_buf()
+      assert.equals('canola', vim.bo[canola_bufnr].filetype)
+      vim.bo[canola_bufnr].bufhidden = 'hide'
+
+      vim.cmd.enew()
+      local fugitive_bufnr = vim.api.nvim_get_current_buf()
+      vim.api.nvim_buf_set_name(fugitive_bufnr, 'fugitive://test/.git//0')
+      vim.bo[fugitive_bufnr].filetype = 'fugitive'
+      vim.cmd.only()
+
+      assert.is_function(pending_finish)
+      pending_finish()
+
+      assert.is_true(vim.api.nvim_buf_is_valid(canola_bufnr))
+      assert.equals(fugitive_bufnr, vim.api.nvim_get_current_buf())
+      assert.equals('fugitive', vim.bo[fugitive_bufnr].filetype)
+      assert.equals('canola', vim.bo[canola_bufnr].filetype)
+    end, debug.traceback)
+
+    files.normalize_url = old_normalize_url
+    if not ok then
+      error(err)
+    end
+  end)
+
   it('places the cursor on correct entry when opening on file', function()
     vim.cmd.edit({ args = { '.' } })
     test_util.wait_for_autocmd({ 'User', pattern = 'CanolaEnter' })


### PR DESCRIPTION
## Summary
- finish async directory loads in the target canola buffer context when the original window is gone
- avoid applying canola window options when initialized buffer is hidden
- add regression coverage for issue #345 with a fugitive-like current buffer

Fixes #345

## Tests
- busted --filter=unrelated spec/regression_spec.lua
- busted spec/regression_spec.lua
- busted spec/files_spec.lua
- busted spec/watch_spec.lua
- busted
- stylua --check lua/canola/init.lua lua/canola/view.lua spec/regression_spec.lua
- selene --display-style quiet lua/canola/init.lua lua/canola/view.lua spec/regression_spec.lua
- git diff --check