### PR TITLE
ci: replace prettier with biome

### DIFF
--- a/.github/workflows/upstream-digest.yaml
+++ b/.github/workflows/upstream-digest.yaml
@@ -21,9 +21,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 .github/scripts/upstream_digest.py
 
+      - name: Install Nix
+        if: steps.digest.outputs.changed == 'true'
+        uses: cachix/install-nix-action@v31
+
       - name: Format doc/upstream.md
         if: steps.digest.outputs.changed == 'true'
-        run: npx --yes prettier --write doc/upstream.md
+        run: nix develop .#ci --command biome format --write doc/upstream.md
 
       - name: Push and open PR if needed
         if: steps.digest.outputs.changed == 'true'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "useEditorconfig": true,
+    "includes": ["**", "!**/node_modules/"]
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         pkgs:
         let
           commonPackages = [
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check lua spec
-    prettier --check .
+    biome format .
 
 test:
     busted


### PR DESCRIPTION
## Problem

The `canola` branch still uses Prettier in its formatter path even though the repo should use Biome.

## Solution

- add `biome.json` and replace Prettier with `pkgs.biome` in the devshell
- switch `just format` and the upstream digest formatter to `biome format`
- remove `.prettierrc`

Verification:

- [x] `rg -n 'prettier|prettierrc' . || true`\n- [x] `git diff --check`\n- [x] `nix develop .#ci --command just format`\n- [x] `nix develop .#ci --command just lint`\n- [x] `nix develop .#ci --command just test`