### PR TITLE
ci: replace prettier with biome

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -70,4 +70,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command prettier --check .
+      - run: nix develop --command biome format .

--- a/.github/workflows/upstream-digest.yaml
+++ b/.github/workflows/upstream-digest.yaml
@@ -21,9 +21,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 .github/scripts/upstream_digest.py
 
+      - name: Install Nix
+        if: steps.digest.outputs.changed == 'true'
+        uses: cachix/install-nix-action@v31
+
       - name: Format doc/upstream.md
         if: steps.digest.outputs.changed == 'true'
-        run: npx --yes prettier --write doc/upstream.md
+        run: nix develop --command biome format --write doc/upstream.md
 
       - name: Push and open PR if needed
         if: steps.digest.outputs.changed == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,10 @@ repos:
         files: \.lua$
         pass_filenames: true
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
-      - id: prettier
-        name: prettier
-        files: \.(md|toml|yaml|yml|sh)$
+      - id: biome-format
+        name: biome format
+        entry: biome format --write --no-errors-on-unmatched
+        language: system
+        files: \.(css|html|js|json|jsonc|jsx|md|ts|tsx)$

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "useEditorconfig": true,
+    "includes": ["**", "!**/node_modules/"]
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           packages = [
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
             pkgs.neovim

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -3,7 +3,7 @@ set -eu
 
 nix develop --command stylua --check lua spec
 git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
-nix develop --command prettier --check .
+nix develop --command biome format .
 nix fmt
 git diff --exit-code -- '*.nix'
 nix develop --command busted


### PR DESCRIPTION
## Problem

The GitHub `main` branch still uses Prettier for Markdown formatting even though the repo has moved to Biome on the current maintenance surface.

## Solution

- add `biome.json` and replace Prettier with `pkgs.biome` in the devshell
- switch CI, the local CI script, and the upstream digest formatter to `biome format`
- replace the Prettier pre-commit hook and remove `.prettierrc`

Verification:

- [x] `rg -n 'prettier|prettierrc' . || true`\n- [x] `git diff --check`\n- [x] `nix develop --command biome format .`\n- [x] `nix develop --command stylua --check lua spec`\n- [x] `git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet`\n- [x] `nix develop --command busted`