### PR TITLE
docs(recipes): document sessionoptions blank requirement for sessions

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -1468,6 +1468,17 @@ https://github.com/s1n7ax/nvim-window-picker. Add to `after/ftplugin/oil.lua`:
     end, { buffer = true, desc = "Open file in picked window" })
 <
 
+Session compatibility ~
+                                                         *oil-recipe-sessions*
+With the default 'sessionoptions' (which includes "blank") oil windows are
+saved and restored across |:mksession|. If you remove "blank" from
+'sessionoptions', |:mksession| treats oil buffers ('buftype' is "acwrite") as
+blank windows and omits them, so oil windows are not restored.
+
+Keep "blank" in 'sessionoptions' if you want oil windows to survive a session
+round-trip. Automatic 'buftype' handling depends on a pre-write session event
+tracked upstream at neovim/neovim#22814.
+
 ------------------------------------------------------------------------------
 EVENTS                                                            *oil-events*
 


### PR DESCRIPTION
## Problem

`mksession` treats oil buffers (`buftype='acwrite'`) as blank windows when
`blank` is removed from `sessionoptions`, so oil windows are silently dropped
from saved sessions. Nothing in the help explains this, so the failure looks
like a bug rather than a `sessionoptions` interaction.

## Solution

Add a "Session compatibility" recipe documenting that `blank` must stay in
`sessionoptions` for oil windows to survive a session round-trip, and pointing
at the upstream pre-write session event that would let oil handle `buftype`
automatically. Context in #149; automatic handling tracked in #353.
