### PR TITLE
docs(recipes): document sessionoptions blank requirement for sessions

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -1675,6 +1675,17 @@ https://github.com/s1n7ax/nvim-window-picker. Add to
     end, { buffer = true, desc = "Open file in picked window" })
 <
 
+Session compatibility ~
+                                                      *canola-recipe-sessions*
+With the default 'sessionoptions' (which includes "blank") canola windows are
+saved and restored across |:mksession|. If you remove "blank" from
+'sessionoptions', |:mksession| treats canola buffers ('buftype' is "acwrite")
+as blank windows and omits them, so canola windows are not restored.
+
+Keep "blank" in 'sessionoptions' if you want canola windows to survive a
+session round-trip. Automatic 'buftype' handling depends on a pre-write
+session event tracked upstream at neovim/neovim#22814.
+
 ------------------------------------------------------------------------------
 EVENTS                                                         *canola-events*
 


### PR DESCRIPTION
## Problem

`mksession` treats canola buffers (`buftype='acwrite'`) as blank windows when
`blank` is removed from `sessionoptions`, so canola windows are silently
dropped from saved sessions. Nothing in the help explains this, so the failure
looks like a bug rather than a `sessionoptions` interaction.

## Solution

Add a "Session compatibility" recipe documenting that `blank` must stay in
`sessionoptions` for canola windows to survive a session round-trip, and
pointing at the upstream pre-write session event that would let canola handle
`buftype` automatically. Context in #149; automatic handling tracked in #353.
