### PR TITLE
feat(session): clear buftype via SessionWritePre/Post for mksession

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -1470,14 +1470,14 @@ https://github.com/s1n7ax/nvim-window-picker. Add to `after/ftplugin/oil.lua`:
 
 Session compatibility ~
                                                          *oil-recipe-sessions*
-With the default 'sessionoptions' (which includes "blank") oil windows are
-saved and restored across |:mksession|. If you remove "blank" from
-'sessionoptions', |:mksession| treats oil buffers ('buftype' is "acwrite") as
-blank windows and omits them, so oil windows are not restored.
+On Neovim with the SessionWritePre event, oil clears 'buftype' around
+|:mksession| automatically, so oil windows are saved and restored across a
+session round-trip regardless of 'sessionoptions'.
 
-Keep "blank" in 'sessionoptions' if you want oil windows to survive a session
-round-trip. Automatic 'buftype' handling depends on a pre-write session event
-tracked upstream at neovim/neovim#22814.
+On older Neovim without SessionWritePre, |:mksession| treats oil buffers
+('buftype' is "acwrite") as blank windows and omits them when "blank" is not in
+'sessionoptions'. Keep "blank" in 'sessionoptions' there if you want oil
+windows to survive a session round-trip.
 
 ------------------------------------------------------------------------------
 EVENTS                                                            *oil-events*

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1593,6 +1593,45 @@ M.setup = function(opts)
     end,
   })
 
+  -- Oil buffers use buftype=acwrite, which mksession treats as a blank window
+  -- when "blank" is excluded from 'sessionoptions', dropping them from the
+  -- session. Clear buftype before the session is written so their oil:// urls
+  -- are saved, then restore it afterwards. Requires the SessionWritePre event.
+  if vim.fn.exists('##SessionWritePre') == 1 then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    vim.api.nvim_create_autocmd('SessionWritePre', {
+      desc = 'Clear buftype on oil buffers so mksession saves their urls',
+      group = aug,
+      pattern = '*',
+      callback = function()
+        local util = require('oil.util')
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          if
+            vim.api.nvim_buf_is_valid(bufnr)
+            and util.is_oil_bufnr(bufnr)
+            and vim.bo[bufnr].buftype == 'acwrite'
+          then
+            vim.b[bufnr].oil_session_buftype = vim.bo[bufnr].buftype
+            vim.bo[bufnr].buftype = ''
+          end
+        end
+      end,
+    })
+    vim.api.nvim_create_autocmd('SessionWritePost', {
+      desc = 'Restore buftype on oil buffers after mksession',
+      group = aug,
+      pattern = '*',
+      callback = function()
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          if vim.api.nvim_buf_is_valid(bufnr) and vim.b[bufnr].oil_session_buftype ~= nil then
+            vim.bo[bufnr].buftype = vim.b[bufnr].oil_session_buftype
+            vim.b[bufnr].oil_session_buftype = nil
+          end
+        end
+      end,
+    })
+  end
+
   if config.default_to_float then
     vim.api.nvim_create_autocmd('VimEnter', {
       desc = 'Open oil in a float when starting on a directory',


### PR DESCRIPTION
## Problem

`mksession` treats oil buffers (`buftype='acwrite'`) as blank windows when
`blank` is excluded from `sessionoptions`, so oil windows are dropped from
saved sessions. This hit both exit-time saves (persistence.nvim, auto-session)
and mid-session writes (`:mksession`, `MiniSessions.restart()`). Fixing it
properly needed a pre-write hook, which did not exist until Neovim added
`SessionWritePre` (neovim/neovim#39688).

## Solution

Register `SessionWritePre` to clear `buftype` on oil buffers so the session
writer records their `oil://` urls, and `SessionWritePost` to restore it. Both
are gated on `vim.fn.exists('##SessionWritePre') == 1`, so this is a no-op on
Neovim without the event and activates automatically once it lands in a
release. Because `:mksession` fires these events around every write, it covers
exit-time and mid-session writes and does not depend on autocmd ordering
between plugins. `SessionLoadPost` continues to reload buffers on restore. The
session recipe in the help is updated to match.

Closes #149
Closes #353
