### PR TITLE
feat(session): clear buftype via SessionWritePre/Post for mksession

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -1677,14 +1677,14 @@ https://github.com/s1n7ax/nvim-window-picker. Add to
 
 Session compatibility ~
                                                       *canola-recipe-sessions*
-With the default 'sessionoptions' (which includes "blank") canola windows are
-saved and restored across |:mksession|. If you remove "blank" from
-'sessionoptions', |:mksession| treats canola buffers ('buftype' is "acwrite")
-as blank windows and omits them, so canola windows are not restored.
+On Neovim with the SessionWritePre event, canola clears 'buftype' around
+|:mksession| automatically, so canola windows are saved and restored across a
+session round-trip regardless of 'sessionoptions'.
 
-Keep "blank" in 'sessionoptions' if you want canola windows to survive a
-session round-trip. Automatic 'buftype' handling depends on a pre-write
-session event tracked upstream at neovim/neovim#22814.
+On older Neovim without SessionWritePre, |:mksession| treats canola buffers
+('buftype' is "acwrite") as blank windows and omits them when "blank" is not in
+'sessionoptions'. Keep "blank" in 'sessionoptions' there if you want canola
+windows to survive a session round-trip.
 
 ------------------------------------------------------------------------------
 EVENTS                                                         *canola-events*

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -769,6 +769,46 @@ M.init = function()
     end,
   })
 
+  -- Canola buffers use buftype=acwrite, which mksession treats as a blank
+  -- window when "blank" is excluded from 'sessionoptions', dropping them from
+  -- the session. Clear buftype before the session is written so their canola://
+  -- urls are saved, then restore it afterwards. Requires the SessionWritePre
+  -- event.
+  if vim.fn.exists('##SessionWritePre') == 1 then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    vim.api.nvim_create_autocmd('SessionWritePre', {
+      desc = 'Clear buftype on canola buffers so mksession saves their urls',
+      group = aug,
+      pattern = '*',
+      callback = function()
+        local util = require('canola.util')
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          if
+            vim.api.nvim_buf_is_valid(bufnr)
+            and util.is_canola_bufnr(bufnr)
+            and vim.bo[bufnr].buftype == 'acwrite'
+          then
+            vim.b[bufnr].canola_session_buftype = vim.bo[bufnr].buftype
+            vim.bo[bufnr].buftype = ''
+          end
+        end
+      end,
+    })
+    vim.api.nvim_create_autocmd('SessionWritePost', {
+      desc = 'Restore buftype on canola buffers after mksession',
+      group = aug,
+      pattern = '*',
+      callback = function()
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          if vim.api.nvim_buf_is_valid(bufnr) and vim.b[bufnr].canola_session_buftype ~= nil then
+            vim.bo[bufnr].buftype = vim.b[bufnr].canola_session_buftype
+            vim.b[bufnr].canola_session_buftype = nil
+          end
+        end
+      end,
+    })
+  end
+
   if config.float.default then
     vim.api.nvim_create_autocmd('VimEnter', {
       desc = 'Open oil in a float when starting on a directory',


### PR DESCRIPTION
## Problem

`mksession` treats canola buffers (`buftype='acwrite'`) as blank windows when
`blank` is excluded from `sessionoptions`, so canola windows are dropped from
saved sessions, for both exit-time saves and mid-session writes (`:mksession`,
`MiniSessions.restart()`). Fixing it needed a pre-write hook, which did not
exist until Neovim added `SessionWritePre` (neovim/neovim#39688).

## Solution

Register `SessionWritePre` to clear `buftype` on canola buffers so the session
writer records their `canola://` urls, and `SessionWritePost` to restore it,
gated on `vim.fn.exists('##SessionWritePre') == 1` (no-op on Neovim without the
event). `:mksession` fires the events around every write, so this covers
exit-time and mid-session writes without depending on autocmd ordering. The
session recipe in the help is updated to match.

Canola-branch counterpart of #356. Issues #149 and #353 are closed by that PR.
