### PR TITLE
feat(plugin): add vim.g.loaded_canola load guard

### DIFF
--- a/plugin/canola.lua
+++ b/plugin/canola.lua
@@ -1,1 +1,6 @@
+if vim.g.loaded_canola then
+  return
+end
+vim.g.loaded_canola = 1
+
 require('canola').init()


### PR DESCRIPTION
## Problem

`plugin/canola.lua` calls `require('canola').init()` unconditionally on load.
There's no load guard, so canola can't be disabled the conventional way
(`vim.g.loaded_canola` before load), and re-sourcing the plugin re-runs
`init()`.

## Solution

Add the standard `vim.g.loaded_canola` guard. Setting it before load opts out
(mirrors `vim.g.loaded_netrw`), and it makes plugin load idempotent. Canola
track only; `main`'s `plugin/oil.lua` stays oil-compatible (it doesn't
auto-init).
