### PR TITLE
fix(config): preserve explicitly-set list values after deep extend

### DIFF
--- a/lua/canola/config.lua
+++ b/lua/canola/config.lua
@@ -273,6 +273,13 @@ M.init = function()
 
   local new_conf = vim.tbl_deep_extend('keep', opts, default_config)
 
+  -- vim.tbl_deep_extend merges lists element-by-element, so an explicit
+  -- empty list (e.g. columns = {}) gets overridden by the default. Restore
+  -- any list-valued keys the user explicitly set.
+  if opts.columns ~= nil then
+    new_conf.columns = opts.columns
+  end
+
   local user_keymaps = opts.keymaps or {}
   new_conf.keymaps = vim.tbl_deep_extend('keep', {}, default_keymaps)
   for k, v in pairs(user_keymaps) do


### PR DESCRIPTION
## Problem

`vim.tbl_deep_extend` merges lists element-by-element rather than replacing them. This means an explicitly empty list in `vim.g.canola` (e.g. `columns = {}`) is overridden by the default `{ 'icon' }`, making it impossible to clear the columns list via config.

## Fix

After the deep extend, restore `columns` if the user explicitly set it in `vim.g.canola`.

## Reproduction

```lua
vim.g.canola = { columns = {} }

-- After a canola buffer opens:
vim.defer_fn(function()
  vim.notify(vim.inspect(require('canola.config').columns))
  -- Before fix: { "icon" }
  -- After fix:  {}
end, 1000)
```

## Notes

This affects any user who wants to remove the built-in icon column (e.g. when using a plugin like [real-icons.nvim](https://github.com/Mirsmog/real-icons.nvim) that renders its own icons). The same `vim.tbl_deep_extend` limitation applies to other list-valued config keys — `columns` is the most common case.