### PR TITLE
fix: support nightly :restart

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -337,6 +337,12 @@ local function maybe_hijack_directory_buffer(bufnr)
   if bufname == '' then
     return false
   end
+  if vim.v.startreason == 'restart' then
+    if vim.fn.isdirectory(bufname) == 1 then
+      vim.api.nvim_buf_delete(bufnr, {})
+    end
+    return false
+  end
   if util.parse_url(bufname) or vim.fn.isdirectory(bufname) == 0 then
     return false
   end


### PR DESCRIPTION
## Problem

Canola can hijack plain directory buffers while Neovim is restoring a session-backed `:restart`, which interferes with the restored window and buffer state.

## Solution

Skip the default file explorer hijack when `v:startreason` is `restart`, and remove the transient directory buffer so Neovim can finish restoring the session cleanly.