### PR TITLE
fix(init): keep canola filetype after directory reads

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -466,6 +466,7 @@ M.load_oil_buffer = function(bufnr)
         vim.cmd.doautocmd({ args = { 'BufReadPre', bufname }, mods = { emsg_silent = true } })
         view.initialize(bufnr)
         vim.cmd.doautocmd({ args = { 'BufReadPost', bufname }, mods = { emsg_silent = true } })
+        view.set_filetype(bufnr)
       else
         vim.bo[bufnr].buftype = 'acwrite'
         adapter.read_file(bufnr)

--- a/lua/canola/view.lua
+++ b/lua/canola/view.lua
@@ -275,6 +275,18 @@ M.set_win_options = function()
   end
 end
 
+M.set_filetype = function(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  if vim.bo[bufnr].syntax ~= 'canola' then
+    vim.bo[bufnr].syntax = 'canola'
+  end
+  if vim.bo[bufnr].filetype ~= 'canola' then
+    vim.bo[bufnr].filetype = 'canola'
+  end
+end
+
 ---Get a list of visible oil buffers and a list of hidden oil buffers
 ---@note
 --- If any buffers are modified, return values are nil
@@ -335,8 +347,7 @@ M.initialize = function(bufnr)
   vim.bo[bufnr].buftype = 'acwrite'
   vim.bo[bufnr].readonly = false
   vim.bo[bufnr].swapfile = false
-  vim.bo[bufnr].syntax = 'canola'
-  vim.bo[bufnr].filetype = 'canola'
+  M.set_filetype(bufnr)
   vim.bo[bufnr].cindent = false
   vim.bo[bufnr].smartindent = false
   vim.bo[bufnr].indentexpr = ''


### PR DESCRIPTION
## Problem

Neovim's directory filetype detection can classify slash-terminated Canola directory buffers as `directory` after Canola has initialized them. That leaves the buffer rendered by Canola but no longer identified as a Canola buffer, so concealed internal IDs and buffer APIs no longer behave as intended.

## Solution

Canola now centralizes its directory-buffer filetype setup and reapplies it after the synthetic directory read autocmds have run. This keeps Canola buffers identified as Canola buffers even when the runtime's directory fallback sees the slash-terminated URL.