### PR TITLE
fix(init): keep oil filetype after directory reads

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1271,6 +1271,7 @@ M.load_oil_buffer = function(bufnr)
         vim.cmd.doautocmd({ args = { 'BufReadPre', bufname }, mods = { emsg_silent = true } })
         view.initialize(bufnr)
         vim.cmd.doautocmd({ args = { 'BufReadPost', bufname }, mods = { emsg_silent = true } })
+        view.set_filetype(bufnr)
       else
         vim.bo[bufnr].buftype = 'acwrite'
         adapter.read_file(bufnr)

--- a/lua/oil/view.lua
+++ b/lua/oil/view.lua
@@ -225,6 +225,18 @@ M.set_win_options = function()
   end
 end
 
+M.set_filetype = function(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  if vim.bo[bufnr].syntax ~= 'oil' then
+    vim.bo[bufnr].syntax = 'oil'
+  end
+  if vim.bo[bufnr].filetype ~= 'oil' then
+    vim.bo[bufnr].filetype = 'oil'
+  end
+end
+
 ---Get a list of visible oil buffers and a list of hidden oil buffers
 ---@note
 --- If any buffers are modified, return values are nil
@@ -599,8 +611,7 @@ M.initialize = function(bufnr)
   vim.bo[bufnr].buftype = 'acwrite'
   vim.bo[bufnr].readonly = false
   vim.bo[bufnr].swapfile = false
-  vim.bo[bufnr].syntax = 'oil'
-  vim.bo[bufnr].filetype = 'oil'
+  M.set_filetype(bufnr)
   vim.b[bufnr].EditorConfig_disable = 1
   session[bufnr] = session[bufnr] or {}
   for k, v in pairs(config.buf_options) do


### PR DESCRIPTION
## Problem

Neovim's directory filetype detection can classify slash-terminated Oil directory buffers as `directory` after Oil has initialized them. That leaves the buffer rendered by Oil but no longer identified as an Oil buffer, so concealed internal IDs and buffer APIs no longer behave as intended.

## Solution

Oil now centralizes its directory-buffer filetype setup and reapplies it after the synthetic directory read autocmds have run. This keeps Oil buffers identified as Oil buffers even when the runtime's directory fallback sees the slash-terminated URL.