### PR TITLE
fix(init): disable builtin dir plugin

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -43,6 +43,9 @@ Open a project directory when you want to browse and edit it as a buffer: >
     nvim .
 <
 
+canola.nvim always acts as the default directory explorer, so it disables
+Neovim's built-in directory browsers automatically.
+
 Open another directory from inside Neovim when you already know the path: >
     :Canola <path>
 <

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -613,6 +613,7 @@ M.init = function()
 
   vim.g.loaded_netrw = 1
   vim.g.loaded_netrwPlugin = 1
+  vim.g.loaded_nvim_dir_plugin = 1
   if vim.fn.exists('#FileExplorer') then
     vim.api.nvim_create_augroup('FileExplorer', { clear = true })
   end


### PR DESCRIPTION
## Problem

Recent Neovim nightlies include a builtin directory browser. canola always acts as the default directory explorer, so allowing that plugin to load creates another owner for the same directory buffers.

## Solution

Mark Neovim's builtin directory browser as loaded alongside netrw during canola startup, and document that canola disables the builtin directory browsers automatically.