### PR TITLE
fix(init): disable builtin dir plugin

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -46,6 +46,11 @@ Open a project directory when you want to browse and edit it as a buffer: >
     nvim .
 <
 
+When `default_file_explorer` is enabled, oil disables Neovim's built-in
+directory browsers before taking over directory buffers. If you disable
+`default_file_explorer`, set `vim.g.loaded_nvim_dir_plugin = 1` before startup
+if you also want Neovim's built-in directory browser disabled.
+
 Open another directory from inside Neovim when you already know the path: >
     :Oil <path>
 <

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -990,7 +990,8 @@ local function maybe_hijack_directory_buffer(bufnr)
   if bufname == '' then
     return false
   end
-  if vim.v.startreason == "restart" then
+  ---@diagnostic disable-next-line: undefined-field
+  if vim.v.startreason == 'restart' then
     if vim.fn.isdirectory(bufname) == 1 then
       vim.api.nvim_buf_delete(bufnr, {})
     end

--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -1389,6 +1389,7 @@ M.setup = function(opts)
   if config.default_file_explorer then
     vim.g.loaded_netrw = 1
     vim.g.loaded_netrwPlugin = 1
+    vim.g.loaded_nvim_dir_plugin = 1
     -- If netrw was already loaded, clear this augroup
     if vim.fn.exists('#FileExplorer') then
       vim.api.nvim_create_augroup('FileExplorer', { clear = true })


### PR DESCRIPTION
## Problem

Recent Neovim nightlies include a builtin directory browser. When oil is configured as the default file explorer, that builtin plugin creates another owner for local directory buffers.

## Solution

Mark Neovim's builtin directory browser as loaded alongside netrw when `default_file_explorer` is enabled, and document the manual flag for configurations that disable oil's default explorer behavior.