### PR TITLE
fix(init): load startup canola buffers reliably

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -420,7 +420,7 @@ M.load_oil_buffer = function(bufnr)
   end
 
   -- Early return if we're already loading or have already loaded this buffer
-  if loading.is_loading(bufnr) or vim.b[bufnr].filetype ~= nil then
+  if loading.is_loading(bufnr) then
     return
   end
 
@@ -614,6 +614,7 @@ M.init = function()
   vim.g.loaded_netrw = 1
   vim.g.loaded_netrwPlugin = 1
   vim.g.loaded_nvim_dir_plugin = 1
+  pcall(vim.api.nvim_del_augroup_by_name, 'nvim.dir')
   if vim.fn.exists('#FileExplorer') then
     vim.api.nvim_create_augroup('FileExplorer', { clear = true })
   end
@@ -840,14 +841,22 @@ M.init = function()
     pattern = '*',
     nested = true,
     callback = function(params)
-      if maybe_hijack_directory_buffer(params.buf) and vim.v.vim_did_enter == 1 then
+      local util = require('canola.util')
+      if
+        maybe_hijack_directory_buffer(params.buf)
+        or (util.is_canola_bufnr(params.buf) and not vim.b[params.buf].canola_ready)
+      then
         M.load_oil_buffer(params.buf)
       end
     end,
   })
 
+  local util = require('canola.util')
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if maybe_hijack_directory_buffer(bufnr) and vim.v.vim_did_enter == 1 then
+    if
+      maybe_hijack_directory_buffer(bufnr)
+      or (util.is_canola_bufnr(bufnr) and not vim.b[bufnr].canola_ready)
+    then
       M.load_oil_buffer(bufnr)
     end
   end

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -421,6 +421,11 @@ M.load_oil_buffer = function(bufnr)
 
   -- Early return if we're already loading or have already loaded this buffer
   if loading.is_loading(bufnr) then
+    if vim.endswith(bufname, '/') then
+      vim.bo[bufnr].filetype = 'canola'
+      vim.bo[bufnr].buftype = 'acwrite'
+      keymap_util.set_keymaps(config.keymaps, bufnr)
+    end
     return
   end
 

--- a/lua/canola/util.lua
+++ b/lua/canola/util.lua
@@ -149,7 +149,10 @@ M.rename_buffer = function(src_bufnr, dest_buf_name)
       -- Renaming the buffer creates a new buffer with the old name.
       -- Find it and try to delete it, but don't if the buffer is in a context
       -- where Neovim doesn't allow buffer modifications.
-      pcall(vim.api.nvim_buf_delete, vim.fn.bufadd(bufname), {})
+      local old_bufnr = vim.fn.bufadd(bufname)
+      if old_bufnr ~= src_bufnr then
+        pcall(vim.api.nvim_buf_delete, old_bufnr, {})
+      end
       if altbuf and vim.api.nvim_buf_is_valid(altbuf) then
         vim.fn.setreg('#', altbuf)
       end

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -26,4 +26,15 @@ describe('util', function()
       assert.equals(expected, output)
     end
   end)
+
+  it('does not delete a renamed buffer when the old name resolves to the same buffer', function()
+    local bufnr = vim.api.nvim_create_buf(false, false)
+    vim.api.nvim_buf_set_name(bufnr, 'canola-test:///foo')
+
+    local replaced = util.rename_buffer(bufnr, 'canola-test:///foo/')
+
+    assert.is_false(replaced)
+    assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+    assert.equals('canola-test:///foo/', vim.api.nvim_buf_get_name(bufnr))
+  end)
 end)


### PR DESCRIPTION
## Problem

Startup-time directory and canola-url buffers can be created before Neovim has finished entering the UI. In that window, buffer renames can resolve the old name back to the same buffer, and canola can skip loading buffers until after startup state changes.

## Solution

Guard buffer cleanup during rename so the just-renamed buffer is not deleted. Load hijacked directory buffers and not-ready canola buffers immediately during startup/setup, and clear Neovim's built-in directory-browser augroup if it was already registered.