### PR TITLE
feat(rename): add canola entry name transform

### DIFF
--- a/doc/canola.txt
+++ b/doc/canola.txt
@@ -695,6 +695,27 @@ set_is_hidden_file({is_hidden_file})               *canola.set_is_hidden_file*
 toggle_hidden()                                         *canola.toggle_hidden*
     Toggle hidden files and directories
 
+rename.transform({callback}, {opts})                 *canola.rename.transform*
+    Transform entry names in the current canola buffer. This edits the buffer
+    only; filesystem changes happen when the buffer is saved.
+
+    Parameters:
+      {callback} `fun(name: string, entry: canola.Entry): nil|string`
+                 Receives the parsed buffer name and entry. Return the new name,
+                 or nil to leave the name unchanged.
+      {opts}     `nil|canola.RenameTransformOpts`
+          {types} `nil|canola.EntryType[]` Entry types to transform. Defaults
+                  to `{ "file", "link" }`. Include `"directory"` to transform
+                  directories.
+          {bufnr} `nil|integer` Buffer to transform. Defaults to the current
+                  buffer.
+
+    Examples: >lua
+      require("canola.rename").transform(function(name)
+        return name:gsub(" ", "-")
+      end, { types = { "file", "directory", "link" } })
+<
+
 register_column({name}, {column})                     *canola.register_column*
     Register a custom column. The column will be available by name in the
     `columns` config for all adapters. Call this before or during plugin
@@ -1282,6 +1303,23 @@ for adapter documentation and configuration.
 
 ------------------------------------------------------------------------------
 RECIPES                                                       *canola-recipes*
+
+Replace spaces in entry names ~
+                                           *canola-recipe-replace-name-spaces*
+>lua
+    vim.g.canola = {
+      keymaps = {
+        ["gs"] = {
+          desc = "Replace spaces in entry names",
+          callback = function()
+            require("canola.rename").transform(function(name)
+              return name:gsub(" ", "-")
+            end, { types = { "file", "directory", "link" } })
+          end,
+        },
+      },
+    }
+<
 
 Toggle file detail view ~
                                             *canola-recipe-toggle-detail-view*

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -420,7 +420,7 @@ M.load_oil_buffer = function(bufnr)
   end
 
   -- Early return if we're already loading or have already loaded this buffer
-  if loading.is_loading(bufnr) or vim.b[bufnr].filetype ~= nil then
+  if loading.is_loading(bufnr) then
     return
   end
 
@@ -614,6 +614,7 @@ M.init = function()
   vim.g.loaded_netrw = 1
   vim.g.loaded_netrwPlugin = 1
   vim.g.loaded_nvim_dir_plugin = 1
+  pcall(vim.api.nvim_del_augroup_by_name, 'nvim.dir')
   if vim.fn.exists('#FileExplorer') then
     vim.api.nvim_create_augroup('FileExplorer', { clear = true })
   end
@@ -840,14 +841,22 @@ M.init = function()
     pattern = '*',
     nested = true,
     callback = function(params)
-      if maybe_hijack_directory_buffer(params.buf) and vim.v.vim_did_enter == 1 then
+      local util = require('canola.util')
+      if
+        maybe_hijack_directory_buffer(params.buf)
+        or (util.is_canola_bufnr(params.buf) and not vim.b[params.buf].canola_ready)
+      then
         M.load_oil_buffer(params.buf)
       end
     end,
   })
 
+  local util = require('canola.util')
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if maybe_hijack_directory_buffer(bufnr) and vim.v.vim_did_enter == 1 then
+    if
+      maybe_hijack_directory_buffer(bufnr)
+      or (util.is_canola_bufnr(bufnr) and not vim.b[bufnr].canola_ready)
+    then
       M.load_oil_buffer(bufnr)
     end
   end

--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -421,6 +421,11 @@ M.load_oil_buffer = function(bufnr)
 
   -- Early return if we're already loading or have already loaded this buffer
   if loading.is_loading(bufnr) then
+    if vim.endswith(bufname, '/') then
+      vim.bo[bufnr].filetype = 'canola'
+      vim.bo[bufnr].buftype = 'acwrite'
+      keymap_util.set_keymaps(config.keymaps, bufnr)
+    end
     return
   end
 

--- a/lua/canola/rename.lua
+++ b/lua/canola/rename.lua
@@ -1,0 +1,120 @@
+local fs = require('canola.fs')
+local parser = require('canola.mutator.parser')
+local util = require('canola.util')
+
+local M = {}
+
+local default_types = {
+  file = true,
+  link = true,
+}
+
+local path_sep_pattern = fs.is_windows and '[/\\]' or '/'
+
+local function build_type_filter(types)
+  if not types then
+    return default_types
+  end
+  local ret = {}
+  for _, entry_type in ipairs(types) do
+    ret[entry_type] = true
+  end
+  return ret
+end
+
+local function get_display_suffix(text)
+  return text:match('([/\\])$') or ''
+end
+
+local function check_name(name, seen_names, lnum)
+  if name == '' then
+    return string.format('Empty filename on line %d', lnum)
+  elseif name:match(path_sep_pattern) then
+    return string.format('Filename cannot contain path separator: %s', name)
+  end
+
+  local key = (fs.is_mac or fs.is_windows) and name:lower() or name
+  if seen_names[key] then
+    return string.format('Duplicate filename: %s', name)
+  end
+  seen_names[key] = true
+end
+
+---@class canola.RenameTransformOpts
+---@field types? canola.EntryType[]
+---@field bufnr? integer
+
+---@param callback fun(name: string, entry: canola.Entry): nil|string
+---@param opts? canola.RenameTransformOpts
+---@return boolean success
+---@return nil|string err
+M.transform = function(callback, opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local adapter = util.get_adapter(bufnr, true)
+  if not adapter then
+    return false,
+      string.format(
+        "Cannot rename entries in buffer '%s': No adapter",
+        vim.api.nvim_buf_get_name(bufnr)
+      )
+  end
+
+  local type_filter = build_type_filter(opts.types)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
+  local edits = {}
+  local seen_names = {}
+
+  for i, line in ipairs(lines) do
+    local result, parse_err = parser.parse_line(adapter, line, nil)
+    if not result and line:match('^/%d+') then
+      return false, string.format('Error parsing line %d: %s', i, parse_err)
+    end
+    if result and result.entry and result.data.id ~= 0 then
+      local entry = util.export_entry(result.entry)
+      local current_name = result.data.name
+      if type_filter[entry.type] and current_name then
+        entry.parsed_name = current_name
+        local next_name = callback(current_name, entry)
+        if next_name == nil then
+          next_name = current_name
+        end
+        if type(next_name) ~= 'string' then
+          return false, string.format('Rename callback returned %s for line %d', type(next_name), i)
+        end
+        local err = check_name(next_name, seen_names, i)
+        if err then
+          return false, err
+        end
+        if next_name ~= current_name then
+          local range = result.ranges and result.ranges.name
+          if not range then
+            return false, string.format('Could not find filename range on line %d', i)
+          end
+          local range_text = line:sub(range[1] + 1, range[2] + 1)
+          local suffix = get_display_suffix(range_text)
+          local before = line:sub(1, range[1])
+          local after = line:sub(range[2] + 2)
+          edits[i] = before .. next_name .. suffix .. after
+        end
+      elseif current_name then
+        local err = check_name(current_name, seen_names, i)
+        if err then
+          return false, err
+        end
+      end
+    end
+  end
+
+  if next(edits) == nil then
+    return true
+  end
+
+  for i, line in pairs(edits) do
+    lines[i] = line
+  end
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
+  return true
+end
+
+return M

--- a/lua/canola/util.lua
+++ b/lua/canola/util.lua
@@ -149,7 +149,10 @@ M.rename_buffer = function(src_bufnr, dest_buf_name)
       -- Renaming the buffer creates a new buffer with the old name.
       -- Find it and try to delete it, but don't if the buffer is in a context
       -- where Neovim doesn't allow buffer modifications.
-      pcall(vim.api.nvim_buf_delete, vim.fn.bufadd(bufname), {})
+      local old_bufnr = vim.fn.bufadd(bufname)
+      if old_bufnr ~= src_bufnr then
+        pcall(vim.api.nvim_buf_delete, old_bufnr, {})
+      end
       if altbuf and vim.api.nvim_buf_is_valid(altbuf) then
         vim.fn.setreg('#', altbuf)
       end

--- a/spec/rename_spec.lua
+++ b/spec/rename_spec.lua
@@ -1,0 +1,119 @@
+local constants = require('canola.constants')
+local parser = require('canola.mutator.parser')
+local rename = require('canola.rename')
+local test_adapter = require('canola.adapters.test')
+local test_util = require('spec.test_util')
+local util = require('canola.util')
+
+local FIELD_ID = constants.FIELD_ID
+local FIELD_META = constants.FIELD_META
+
+local function open_foo()
+  test_util.actions.open({ 'canola-test:///foo/' })
+end
+
+local function lines()
+  return vim.api.nvim_buf_get_lines(0, 0, -1, true)
+end
+
+local function line_text()
+  return table.concat(lines(), '\n')
+end
+
+local function assert_contains(text, needle)
+  assert.truthy(text:find(needle, 1, true))
+end
+
+local function assert_not_contains(text, needle)
+  assert.falsy(text:find(needle, 1, true))
+end
+
+local function find_line(needle)
+  for i, line in ipairs(lines()) do
+    if line:find(needle, 1, true) then
+      return i, line
+    end
+  end
+end
+
+describe('rename transform', function()
+  after_each(function()
+    test_util.reset_editor()
+  end)
+
+  it('renames files and links by default', function()
+    local file = test_adapter.test_set('/foo/alpha file.txt', 'file')
+    test_adapter.test_set('/foo/delta directory', 'directory')
+    local link = test_adapter.test_set('/foo/link item', 'link')
+    link[FIELD_META] = { link = 'target file.txt' }
+    open_foo()
+    local seen = {}
+
+    local ok, err = rename.transform(function(name, entry)
+      seen[entry.id] = name
+      return name:gsub(' ', '-')
+    end)
+
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.equals('alpha file.txt', seen[file[FIELD_ID]])
+    assert.equals('link item', seen[link[FIELD_ID]])
+    local text = line_text()
+    assert_contains(text, 'alpha-file.txt')
+    assert_contains(text, 'delta directory/')
+    assert_contains(text, 'link-item -> target file.txt')
+    assert_not_contains(text, 'target-file.txt')
+  end)
+
+  it('renames directories when opted in', function()
+    test_adapter.test_set('/foo/delta directory', 'directory')
+    open_foo()
+
+    local ok, err = rename.transform(function(name)
+      return name:gsub(' ', '-')
+    end, { types = { 'directory' } })
+
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert_contains(line_text(), 'delta-directory/')
+  end)
+
+  it('leaves the buffer unchanged on duplicate names', function()
+    test_adapter.test_set('/foo/alpha file.txt', 'file')
+    test_adapter.test_set('/foo/bravo file.txt', 'file')
+    open_foo()
+    local before = lines()
+
+    local ok, err = rename.transform(function()
+      return 'same.txt'
+    end)
+
+    assert.is_false(ok)
+    assert.matches('Duplicate filename: same%.txt', err)
+    assert.are.same(before, lines())
+  end)
+
+  it('uses the current parsed buffer name', function()
+    test_adapter.test_set('/foo/alpha file.txt', 'file')
+    open_foo()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local adapter = assert(util.get_adapter(bufnr, true))
+    local lnum, line = find_line('alpha file.txt')
+    assert.truthy(lnum)
+    local result = assert(parser.parse_line(adapter, line, nil))
+    local range = result.ranges.name
+    local edited = line:sub(1, range[1]) .. 'alpha edited.txt' .. line:sub(range[2] + 2)
+    vim.api.nvim_buf_set_lines(bufnr, lnum - 1, lnum, true, { edited })
+    local observed
+
+    local ok, err = rename.transform(function(name)
+      observed = name
+      return name:gsub(' ', '-')
+    end)
+
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.equals('alpha edited.txt', observed)
+    assert_contains(line_text(), 'alpha-edited.txt')
+  end)
+end)

--- a/spec/util_spec.lua
+++ b/spec/util_spec.lua
@@ -26,4 +26,15 @@ describe('util', function()
       assert.equals(expected, output)
     end
   end)
+
+  it('does not delete a renamed buffer when the old name resolves to the same buffer', function()
+    local bufnr = vim.api.nvim_create_buf(false, false)
+    vim.api.nvim_buf_set_name(bufnr, 'canola-test:///foo')
+
+    local replaced = util.rename_buffer(bufnr, 'canola-test:///foo/')
+
+    assert.is_false(replaced)
+    assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+    assert.equals('canola-test:///foo/', vim.api.nvim_buf_get_name(bufnr))
+  end)
 end)


### PR DESCRIPTION
## Problem

Canola users can rename entries by editing buffer text, but keymaps and scripts do not have a safe API for transforming just the displayed entry names. Direct substitutions over rendered lines can accidentally touch internal IDs, link targets, or other non-name text.

## Solution

This adds `canola.rename.transform(callback, opts)`, which parses canola buffer lines, applies a callback to entry names, validates empty names, path separators, and duplicates, and rewrites only the parsed name range. The default transform set matches the oil PR by applying to files and links, with directories available through `opts.types`.

The branch also carries the startup canola-buffer loading fixes already proposed separately so the feature branch is self-contained against the current canola base.