### PR TITLE
fix(init): scope restart directory handling

### DIFF
--- a/lua/canola/init.lua
+++ b/lua/canola/init.lua
@@ -337,7 +337,7 @@ local function maybe_hijack_directory_buffer(bufnr)
   if bufname == '' then
     return false
   end
-  if vim.v.startreason == 'restart' then
+  if vim.v.startreason == 'restart' and vim.v.vim_did_enter == 0 then
     if vim.fn.isdirectory(bufname) == 1 then
       vim.api.nvim_buf_delete(bufnr, {})
     end
@@ -351,6 +351,17 @@ local function maybe_hijack_directory_buffer(bufnr)
   )
   local replaced = util.rename_buffer(bufnr, new_name)
   return not replaced
+end
+
+local function maybe_load_directory_buffer(bufnr)
+  local hijacked = maybe_hijack_directory_buffer(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  local util = require('canola.util')
+  if hijacked or (util.is_canola_bufnr(bufnr) and not vim.b[bufnr].canola_ready) then
+    M.load_oil_buffer(bufnr)
+  end
 end
 
 ---@private
@@ -846,24 +857,12 @@ M.init = function()
     pattern = '*',
     nested = true,
     callback = function(params)
-      local util = require('canola.util')
-      if
-        maybe_hijack_directory_buffer(params.buf)
-        or (util.is_canola_bufnr(params.buf) and not vim.b[params.buf].canola_ready)
-      then
-        M.load_oil_buffer(params.buf)
-      end
+      maybe_load_directory_buffer(params.buf)
     end,
   })
 
-  local util = require('canola.util')
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-    if
-      maybe_hijack_directory_buffer(bufnr)
-      or (util.is_canola_bufnr(bufnr) and not vim.b[bufnr].canola_ready)
-    then
-      M.load_oil_buffer(bufnr)
-    end
+    maybe_load_directory_buffer(bufnr)
   end
 end
 

--- a/spec/regression_spec.lua
+++ b/spec/regression_spec.lua
@@ -45,6 +45,16 @@ local function with_icon_modules_stubbed(devicons, cb)
   end
 end
 
+local function with_vvars(values, cb)
+  local old_v = vim.v
+  vim.v = setmetatable(values, { __index = old_v })
+  local ok, err = xpcall(cb, debug.traceback)
+  vim.v = old_v
+  if not ok then
+    error(err)
+  end
+end
+
 describe('regression tests', function()
   local tmpdir
   before_each(function()
@@ -68,6 +78,23 @@ describe('regression tests', function()
     vim.cmd.edit({ args = { '%:p:h' } })
     test_util.wait_for_autocmd({ 'User', pattern = 'CanolaEnter' })
     assert.equals('canola', vim.bo.filetype)
+  end)
+
+  it('opens directories after restart startup', function()
+    with_vvars({ startreason = 'restart', vim_did_enter = 1 }, function()
+      vim.cmd.edit({ args = { tmpdir.path } })
+      test_util.wait_for_autocmd({ 'User', pattern = 'CanolaEnter' })
+      assert.equals('canola', vim.bo.filetype)
+      assert.is_true(vim.b.canola_ready)
+    end)
+  end)
+
+  it('discards directory buffers while restoring a restart session', function()
+    with_vvars({ startreason = 'restart', vim_did_enter = 0 }, function()
+      vim.cmd.edit({ args = { tmpdir.path } })
+      assert.equals('', vim.api.nvim_buf_get_name(0))
+      assert.not_equals('canola', vim.bo.filetype)
+    end)
   end)
 
   it("doesn't finish async directory loads in an unrelated current buffer", function()


### PR DESCRIPTION
## Problem

`v:startreason` remains `restart` for the lifetime of a restarted process, so Canola continues deleting directory buffers after session restoration has finished. The newer startup-loading path then inspects that deleted buffer, producing an invalid buffer ID error for `:edit <directory>`.

## Solution

Limit transient directory cleanup to the pre-`VimEnter` restoration phase and centralize directory loading behind a buffer-validity boundary. This preserves the existing session-restoration safeguard while restoring normal directory ownership after startup.

Closes #372