### PR TITLE
fix(init): scope restart directory handling

### DIFF
--- a/lua/oil/init.lua
+++ b/lua/oil/init.lua
@@ -991,7 +991,7 @@ local function maybe_hijack_directory_buffer(bufnr)
     return false
   end
   ---@diagnostic disable-next-line: undefined-field
-  if vim.v.startreason == 'restart' then
+  if vim.v.startreason == 'restart' and vim.v.vim_did_enter == 0 then
     if vim.fn.isdirectory(bufname) == 1 then
       vim.api.nvim_buf_delete(bufnr, {})
     end
@@ -1005,6 +1005,17 @@ local function maybe_hijack_directory_buffer(bufnr)
   )
   local replaced = util.rename_buffer(bufnr, new_name)
   return not replaced
+end
+
+local function maybe_load_directory_buffer(bufnr)
+  local hijacked = maybe_hijack_directory_buffer(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  local util = require('oil.util')
+  if hijacked or (util.is_oil_bufnr(bufnr) and not vim.b[bufnr].oil_ready) then
+    M.load_oil_buffer(bufnr)
+  end
 end
 
 ---@private
@@ -1671,24 +1682,12 @@ M.setup = function(opts)
       pattern = '*',
       nested = true,
       callback = function(params)
-        local util = require('oil.util')
-        if
-          maybe_hijack_directory_buffer(params.buf)
-          or (util.is_oil_bufnr(params.buf) and not vim.b[params.buf].oil_ready)
-        then
-          M.load_oil_buffer(params.buf)
-        end
+        maybe_load_directory_buffer(params.buf)
       end,
     })
 
-    local util = require('oil.util')
     for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
-      if
-        maybe_hijack_directory_buffer(bufnr)
-        or (util.is_oil_bufnr(bufnr) and not vim.b[bufnr].oil_ready)
-      then
-        M.load_oil_buffer(bufnr)
-      end
+      maybe_load_directory_buffer(bufnr)
     end
   end
 end

--- a/spec/regression_spec.lua
+++ b/spec/regression_spec.lua
@@ -4,6 +4,16 @@ local oil = require('oil')
 local test_util = require('spec.test_util')
 local view = require('oil.view')
 
+local function with_vvars(values, cb)
+  local old_v = vim.v
+  vim.v = setmetatable(values, { __index = old_v })
+  local ok, err = xpcall(cb, debug.traceback)
+  vim.v = old_v
+  if not ok then
+    error(err)
+  end
+end
+
 describe('regression tests', function()
   local tmpdir
   before_each(function()
@@ -27,6 +37,23 @@ describe('regression tests', function()
     vim.cmd.edit({ args = { '%:p:h' } })
     test_util.wait_for_autocmd({ 'User', pattern = 'OilEnter' })
     assert.equals('oil', vim.bo.filetype)
+  end)
+
+  it('opens directories after restart startup', function()
+    with_vvars({ startreason = 'restart', vim_did_enter = 1 }, function()
+      vim.cmd.edit({ args = { tmpdir.path } })
+      test_util.wait_for_autocmd({ 'User', pattern = 'OilEnter' })
+      assert.equals('oil', vim.bo.filetype)
+      assert.is_true(vim.b.oil_ready)
+    end)
+  end)
+
+  it('discards directory buffers while restoring a restart session', function()
+    with_vvars({ startreason = 'restart', vim_did_enter = 0 }, function()
+      vim.cmd.edit({ args = { tmpdir.path } })
+      assert.equals('', vim.api.nvim_buf_get_name(0))
+      assert.not_equals('oil', vim.bo.filetype)
+    end)
   end)
 
   it('places the cursor on correct entry when opening on file', function()


### PR DESCRIPTION
## Problem

The Oil-compatible track has the same restart lifecycle conflict as the Canola branch: `v:startreason` remains `restart` after startup, so later directory edits delete their buffers, and the startup-loading path immediately inspects the invalid buffer ID.

## Solution

Limit transient directory cleanup to the pre-`VimEnter` restoration phase and centralize default-file-explorer loading behind a buffer-validity boundary. This keeps Oil's session-restoration behavior and `default_file_explorer` semantics while restoring normal directory takeover after startup.